### PR TITLE
Add Roll20 Hoard documentation and API script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# The Hoard — Roll20 Roguelike Toolkit
+
+This repository contains documentation and API scripting for running **The Hoard**, a roguelike-inspired game mode layered onto Dungeons & Dragons 5e inside Roll20.  The material is organized to make it easy for a GM to manage in-run currencies, card-driven shops, and long-term progression.
+
+## Contents
+
+- [`docs/hoard-card-system.md`](docs/hoard-card-system.md) — comprehensive overview of the card decks, currencies, and facility dials that power the mode.
+- [`docs/api-commands.md`](docs/api-commands.md) — reference for chat commands exposed by the Roll20 API script.
+- [`scripts/hoard-card-manager.js`](scripts/hoard-card-manager.js) — Roll20 Mod script that automates currency tracking and reroll token usage.
+
+## Getting Started
+
+1. Import the card decks and handouts described in the documentation into your Roll20 game.
+2. Install the API script from `scripts/hoard-card-manager.js` into your game’s Mod Scripts tab.
+3. Use the command reference to award currencies, spend shop resources, and manage reroll tokens during play.
+
+Future updates will expand the automation coverage to include full shop slot generation and deck draws.

--- a/docs/api-commands.md
+++ b/docs/api-commands.md
@@ -1,0 +1,39 @@
+# Hoard API Command Reference
+
+The Roll20 Mod script in `scripts/hoard-card-manager.js` exposes chat commands that help the GM track currencies and reroll tokens during a run.  All commands start with `!hoard`.
+
+> **Security:** Spending and award commands require a GM. Players may check their own totals and spend reroll tokens.  The script stores data in the persistent `state` object, so values survive script restarts.
+
+## Command Summary
+
+| Command | Description |
+| --- | --- |
+| `!hoard help` | Display quick usage information in chat.
+| `!hoard status [--player "Name"]` | Show totals for all tracked players or a specific player.
+| `!hoard award --player "Name" [--scrip N] [--fse N] [--squares N] [--rerolls N]` | Grant currencies or reroll tokens to a player (GM only).
+| `!hoard spend --player "Name" [--scrip N] [--fse N] [--squares N] [--rerolls N]` | Spend resources from a player (GM only). Prevents negative totals.
+| `!hoard set --player "Name" [--scrip N] [--fse N] [--squares N] [--rerolls N]` | Set exact values for a player (GM only).
+| `!hoard reroll [--player "Name"] [--kind slot|die]` | Spend a reroll token. Defaults to the speaker if `--player` is omitted.
+
+Values supplied to `--scrip`, `--fse`, `--squares`, and `--rerolls` are integers.  Prefix a number with `-` when reducing resources through `!hoard award` or `!hoard spend`.
+
+## Examples
+
+- `!hoard award --player "Kaelith" --scrip 20 --rerolls 1` — grant 20 Scrip and a reroll token.
+- `!hoard spend --player "Seraphine" --scrip 45` — spend 45 Scrip on a Greater Relic.
+- `!hoard reroll --kind slot` — the active speaker consumes one reroll token to reroll a shop slot.
+- `!hoard status --player "Morvox"` — check Morvox’s meta currency totals.
+
+## Output Formatting
+
+Resource summaries are rendered as `Scrip / FSE / Squares / Rerolls` lines for each tracked player.  Reroll spend messages call out whether the reroll targeted a shop slot or a d20.
+
+## Extending the Script
+
+The script keeps configuration (rarity weights, dial A) inside a `CONFIG` object.  Extend it to add:
+
+- Shop draw automation that pays the Scrip cost directly from tracked players.
+- Additional currency types or weekly facility trackers.
+- Logging of awards/spends by run number for post-game analysis.
+
+Use the helper functions at the bottom of the script (`adjustResource`, `getOrCreatePlayerState`, etc.) when adding new commands.

--- a/docs/hoard-card-system.md
+++ b/docs/hoard-card-system.md
@@ -1,0 +1,148 @@
+# Hoard Card System Reference (Roll20)
+
+This document translates the Hoard roguelike ruleset into a set of Roll20-ready card decks, currencies, and procedures.  Use it as the authoritative reference while building decks and configuring automation inside the VTT.
+
+## Core Currencies and Tokens
+
+| Resource | Scope | Default Gain | Default Spend | Notes |
+| --- | --- | --- | --- | --- |
+| **Scrip** | In-run | ~20 per room, +40 on the boss | Relics, Boons, Upgrades, shop rerolls | Liquid currency that resets each run.
+| **FSE** | Meta (Hub) | +1 per room, +2 miniboss, +5 boss, +3 first clear | Minting relics, facility upgrades | Track per player between runs.
+| **Squares** | Meta catalyst | 50% drop on miniboss/boss | Signature minting or convert via Bongo | Convertible to 15 Scrip or 5 FSE.
+| **Reroll Tokens** | Per run | 1 from Hall Staging Alcove (Lv 5) + other sources | Reroll a shop slot (15 Scrip) or a single d20 | Hand out as cards or tokens.
+
+**Default dial:** A = 20 FSE per successful run.  Adjust the drop rates above if you tune the difficulty or pacing.
+
+## Deck Overview
+
+| Deck | Purpose | Draw Logic | Pricing / Rewards |
+| --- | --- | --- | --- |
+| **Relics** (Common/Greater/Signature) | Fast, strong in-run pickups. Some can be Minted. | Each shop visit reveals 4 slots. Roll rarity per slot (default: C 55% / G 35% / S 10%) and draw from the matching deck. | Common 25, Greater 45, Signature 80 Scrip. Reroll slot for 15 Scrip (max 2/visit). Full refresh (all 5 slots) for 35 Scrip (max 1/visit).
+| **Boons** (Ancestor-specific) | Modify the chosen Ancestor loadout. | Special slot result “Boon.” Draw 1–3 options from the Ancestor’s pool (rarity suggestion: C 45% / G 40% / S 15%). | Common 35, Greater 55, Signature 90 Scrip. Restrict stacking as needed.
+| **Weapon/Focus Upgrades** | Generic upgrades by weapon or focus (e.g., Staff, Orb, Greataxe). | Special slot result “Upgrade.” Draw 1–2 upgrades that match the equipped weapon/focus. | Basic 40, Advanced 70, Premium 100 Scrip (use tiers instead of rarity).
+| **Keepsakes** | Post-boss reward; unlock Ancestor choice + 1/LR move. | Award on Champion defeat; no shop draw. | N/A. Each card records the guarantee and the long-rest power.
+| **Room Cards** | Script a Corridor run (6–7 per Corridor). | Reveal sequentially. Each shows setup text, hazards, enemies, and rewards. | Default rewards: +1 FSE per room, +2 miniboss, +5 boss, +3 first clear; Square 50% on miniboss/boss.
+| **Enemy Cards** | Condensed stat blocks. | Referenced by Room cards. Include attack summaries, traits, drops, and tags. | Drops may include Scrip/FSE when per-enemy.
+| **Stone Tongue Slabs** | Collectible alphabet puzzle (A→Z). | Place in rooms or caches. Reveal when discovered. | Each card: letter, sentence, vocabulary list, art, placement note.
+| **Shop Control Cards** | Automation helpers (optional). | Coin flip for Special slot, rarity roll cards, reroll tokens. | Use as GM tools to streamline draw procedures.
+
+## Card Schemas
+
+### Relics
+
+- **Name**
+- **Rarity**: Common / Greater / Signature
+- **Type Tags**: Mobility, Sustain, Burst, Defense, Economy, Control, Anti-Boss, etc.
+- **In-Run Text**: Concrete mechanics (charges, triggers, limits such as “once per room”).
+- **Minted Text**: Convert in-run cadence (“once per room”) to out-of-run cadence (“once per short rest”). No attunement cost by default.
+- **Mint Cost**: Derive from dial A (Common 0.5×A, Greater 1.25×A, Signature 3×A + 1 Square).
+- **Notes**: Clarify stacking rules and interactions.
+
+### Boons
+
+- **Name**
+- **Rarity**: Common / Greater / Signature
+- **Ancestor**: e.g., Seraphine the Firewright, Morvox the Tiny Tyrant, Varek the Stoneshaper, Kaelith the Crimson.
+- **Hook**: Short summary (“Amplifies Stoke,” “Adds +1 attack,” “Detonate blinds,” etc.).
+- **Effect Text**: Mechanics, action economy, save DC (usually 8 + PB + casting stat or ancestor-specific).
+- **Stacking Notes**: Record exclusivity (e.g., limit extra attack sources).
+
+### Weapon / Focus Upgrades
+
+- **Name**
+- **Weapon/Focus Tag**: Staff, Orb, Greataxe, Rapier, etc.
+- **Tier**: Basic / Advanced / Premium (priced 40 / 70 / 100 Scrip).
+- **Effect Text**: Gameplay change (“Your staff attack becomes an extra attack once/turn”).
+- **Synergy Tags**: Optional pointers to Ancestors to highlight combos.
+
+### Keepsakes
+
+- **Name**
+- **Ancestor**
+- **Guarantee**: “Appears in your starting choices every run.”
+- **1/Long Rest Move**: Out-of-run ability (e.g., Kaelith’s Finale Shot crit trigger).
+
+### Room Cards
+
+- **Room Number & Title**
+- **Memory Beat**: Narrative hook (1–2 lines).
+- **Setup & Terrain**: Hazards, interactables, special rules (“Hold the doors,” “Brace the seam,” etc.).
+- **Enemies**: Enemy names and counts; reference matching Enemy cards.
+- **Rewards**: Scrip and FSE values, Square drop chance, other loot.
+- **Notes**: Variant dials or reminders.
+
+### Enemy Cards
+
+- **Name & Type** (e.g., *Rot Husk — Undead Minion*)
+- **Role**: Minion / Elite / Boss
+- **AC / HP / Speed**
+- **Attacks & DCs**: Simplify to core options; include recharge icons.
+- **Traits**: Resistances, immunities, hazards triggered.
+- **Drops**: Scrip or FSE per enemy, if applicable.
+- **Tags**: Corridor, damage type, faction.
+
+### Stone Tongue Slabs
+
+- **Letter** (A–Z)
+- **Sentence**
+- **Content Words**: Unique list tied to the cipher letter.
+- **Art**: Slab illustration.
+- **Tag**: Placement or Corridor note.
+
+### Shop Control Helpers
+
+- **Special Slot Coin**: 50/50 Boon vs Upgrade.
+- **Rarity Roll Card**: Use weighted cards for Relic slots (C/G/S).
+- **Reroll Token Card**: Issue to players; discard on spend.
+
+## Facilities & Weekly Effects
+
+### Hall Staging Alcove (Level 5)
+
+- **Always On**: First run each Bastion turn grants 20 temp HP and 1 Reroll Token.
+- **Order — Empower: Loadout Bias (7 days)**: Pick one dial before the next run.
+  - Starter Stipend (50 Scrip)
+  - Advantage on first initiative roll and no surprise
+  - +1 extra Reroll Token
+  - Variant: “Push the Dial” grants two picks.
+
+### Subastion’s Mint Annex (Level 13)
+
+- **Order — Trade: Golden Hour (7 days)**: One Mint receives a 50% FSE discount this week (Square still required for Signature).
+
+## Shop Procedure (GM Reference)
+
+1. **Enter Shop** after Room 3 (mandatory) and optionally after Room 5.
+2. **Deal 4 Relic slots**. Roll rarity per slot with deck weights above.
+3. **Flip Special Coin** to determine Boon or Upgrade.
+4. **If Boon**: Draw 1–3 cards from the active Ancestor’s Boon deck; player may buy one.
+5. **If Upgrade**: Draw 1–2 cards that match the player’s current weapon/focus.
+6. **Purchases** are paid in Scrip. Players may reroll a single slot (15 Scrip, max 2 per visit) or perform one full refresh (35 Scrip).
+7. **Squares Conversion (Bongo)**: 1 Square → 15 Scrip or 5 FSE, player choice.
+
+## Minting Procedure (Hub Phase)
+
+1. **Eligibility**: Only Relics purchased and used in the just-completed run may be minted.
+2. **Costs** (A = 20 FSE):
+   - Common: 10 FSE (0.5×A)
+   - Greater: 25 FSE (1.25×A)
+   - Signature: 60 FSE + 1 Square (3×A + 1 Square)
+3. **Golden Hour Discount**: If active, one Mint costs 50% FSE (Squares unaffected).
+4. **Dusting**: Destroy a Minted Relic to refund 50% of its FSE cost.
+5. **Conversion**: Replace “once per room” with “once per short rest” for out-of-run play; no attunement slot required.
+
+## Start-of-Run Flow
+
+1. Apply Hall Staging Alcove benefits (temp HP, reroll tokens, Loadout Bias bonuses).
+2. Present 2–3 Ancestor Loadout cards (Keepsakes guarantee the linked Ancestor is included).
+3. Enter the Corridor and resolve Room cards in order.
+4. Trigger Shops after the specified rooms; use Boon/Upgrade decks as directed.
+5. Defeat the boss to earn FSE, a chance at a Square, and a Keepsake (on Champion clears).
+6. Return to the Hub for Minting, FSE spending, and facility orders.
+
+## Implementation Notes for Roll20
+
+- Create one Roll20 deck per card category. Tag cards with searchable keywords (e.g., `Relic|Mobility|Signature`).
+- Maintain a GM-only handout with dial values, price tables, and procedure reminders.
+- Provide API macro buttons for shop management (draw slots, reroll, refresh) and currency adjustments.
+- Enemy cards may link to full stat block handouts or include condensed text directly on the card.

--- a/scripts/hoard-card-manager.js
+++ b/scripts/hoard-card-manager.js
@@ -1,0 +1,380 @@
+(() => {
+  'use strict';
+
+  const SCRIPT_NAME = 'Hoard Card Manager';
+  const VERSION = '0.1.0';
+
+  const CONFIG = Object.freeze({
+    dialA: 20,
+    relicWeights: {
+      common: 0.55,
+      greater: 0.35,
+      signature: 0.1
+    },
+    boonWeights: {
+      common: 0.45,
+      greater: 0.4,
+      signature: 0.15
+    }
+  });
+
+  const RESOURCE_KEYS = ['scrip', 'fse', 'squares', 'rerolls'];
+  const RESOURCE_LABELS = {
+    scrip: 'Scrip',
+    fse: 'FSE',
+    squares: 'Squares',
+    rerolls: 'Rerolls'
+  };
+
+  const ensureState = () => {
+    if (!state.Hoard) {
+      state.Hoard = {
+        version: VERSION,
+        config: _.clone(CONFIG),
+        players: {}
+      };
+    }
+
+    state.Hoard.players = state.Hoard.players || {};
+    _.each(state.Hoard.players, (playerState) => ensurePlayerStateDefaults(playerState));
+    state.Hoard.config = state.Hoard.config || _.clone(CONFIG);
+  };
+
+  const ensurePlayerStateDefaults = (playerState) => {
+    RESOURCE_KEYS.forEach((key) => {
+      if (typeof playerState[key] !== 'number' || _.isNaN(playerState[key])) {
+        playerState[key] = 0;
+      }
+    });
+  };
+
+  const onReady = () => {
+    ensureState();
+    log(`${SCRIPT_NAME} v${VERSION} ready.`);
+  };
+
+  const startsWith = (value, prefix) => _.isString(value) && value.slice(0, prefix.length) === prefix;
+
+  const parseArgs = (content) => {
+    const tokens = [];
+    const regex = /"([^"]*)"|([^\s"]+)/g;
+    let match = regex.exec(content);
+    while (match) {
+      tokens.push(match[1] || match[2]);
+      match = regex.exec(content);
+    }
+
+    const args = { _: [] };
+    let i = 0;
+    while (i < tokens.length) {
+      const token = tokens[i];
+      if (startsWith(token, '--')) {
+        const key = token.slice(2).toLowerCase();
+        const nextToken = tokens[i + 1];
+        const value = nextToken && !startsWith(nextToken, '--') ? nextToken : 'true';
+        args[key] = value;
+        i += value === 'true' ? 1 : 2;
+      } else {
+        args._.push(token);
+        i += 1;
+      }
+    }
+
+    return args;
+  };
+
+  const handleInput = (msg) => {
+    if (msg.type !== 'api' || !_.isString(msg.content)) {
+      return;
+    }
+
+    const trimmed = msg.content.trim();
+    if (!trimmed.startsWith('!hoard')) {
+      return;
+    }
+
+    ensureState();
+
+    const args = parseArgs(trimmed);
+    const command = (args._[1] || 'help').toLowerCase();
+
+    switch (command) {
+      case 'help':
+        sendHelp(msg);
+        break;
+      case 'status':
+        handleStatus(args, msg);
+        break;
+      case 'award':
+        if (requireGM(msg)) {
+          handleAdjust(args, msg, 1, 'Awarded');
+        }
+        break;
+      case 'spend':
+        if (requireGM(msg)) {
+          handleAdjust(args, msg, -1, 'Spent');
+        }
+        break;
+      case 'set':
+        if (requireGM(msg)) {
+          handleSet(args, msg);
+        }
+        break;
+      case 'reroll':
+        handleReroll(args, msg);
+        break;
+      default:
+        sendHelp(msg);
+        break;
+    }
+  };
+
+  const requireGM = (msg) => {
+    if (!playerIsGM(msg.playerid)) {
+      whisper(msg.who, 'Only the GM may use that command.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleStatus = (args, msg) => {
+    const targetId = resolvePlayerId(args.player, msg, true);
+    if (targetId === false) {
+      return;
+    }
+
+    if (targetId) {
+      const playerState = getOrCreatePlayerState(targetId);
+      const name = getDisplayName(targetId);
+      whisper(msg.who, formatStatusLine(name, playerState));
+      return;
+    }
+
+    const entries = _.chain(state.Hoard.players)
+      .map((playerState, playerId) => ({
+        id: playerId,
+        name: getDisplayName(playerId),
+        state: playerState
+      }))
+      .sortBy((entry) => entry.name.toLowerCase())
+      .value();
+
+    if (!entries.length) {
+      whisper(msg.who, 'No players are being tracked yet.');
+      return;
+    }
+
+    const lines = entries.map((entry) => formatStatusLine(entry.name, entry.state));
+    whisper(msg.who, lines.join('<br>'));
+  };
+
+  const handleAdjust = (args, msg, multiplier, verb) => {
+    const playerId = resolvePlayerId(args.player, msg);
+    if (!playerId) {
+      return;
+    }
+
+    const adjustments = parseResourceArgs(args);
+    if (_.isEmpty(adjustments)) {
+      whisper(msg.who, 'No resource values supplied.');
+      return;
+    }
+
+    const signedAdjustments = _.reduce(adjustments, (memo, value, key) => {
+      memo[key] = multiplier * value;
+      return memo;
+    }, {});
+    const playerState = getOrCreatePlayerState(playerId);
+    const applied = applyResourceDelta(playerState, signedAdjustments);
+
+    if (_.isEmpty(applied)) {
+      whisper(msg.who, 'No changes were applied (values may have been zero).');
+      return;
+    }
+
+    announceChange(verb, playerId, applied, msg.who);
+  };
+
+  const handleSet = (args, msg) => {
+    const playerId = resolvePlayerId(args.player, msg);
+    if (!playerId) {
+      return;
+    }
+
+    const values = parseResourceArgs(args, { allowZero: true });
+    if (_.isEmpty(values)) {
+      whisper(msg.who, 'No resource values supplied.');
+      return;
+    }
+
+    const playerState = getOrCreatePlayerState(playerId);
+    const applied = {};
+
+    _.each(values, (value, key) => {
+      const prior = playerState[key] || 0;
+      const nextValue = Math.max(0, value);
+      playerState[key] = nextValue;
+      const delta = nextValue - prior;
+      if (delta !== 0) {
+        applied[key] = delta;
+      }
+    });
+
+    if (_.isEmpty(applied)) {
+      whisper(msg.who, 'No changes were applied (values match current totals).');
+      return;
+    }
+
+    announceChange('Set', playerId, applied, msg.who);
+  };
+
+  const handleReroll = (args, msg) => {
+    const resolved = resolvePlayerId(args.player, msg, true);
+    if (resolved === false) {
+      return;
+    }
+
+    const playerId = resolved || msg.playerid;
+    if (!playerId) {
+      whisper(msg.who, 'Unable to determine which player to charge for the reroll.');
+      return;
+    }
+
+    const playerState = getOrCreatePlayerState(playerId);
+    if (playerState.rerolls <= 0) {
+      whisper(msg.who, `${getDisplayName(playerId)} has no reroll tokens remaining.`);
+      return;
+    }
+
+    const kind = (args.kind || 'slot').toLowerCase();
+    const kindLabel = kind === 'die' ? 'd20 reroll' : 'shop slot reroll';
+
+    playerState.rerolls = Math.max(0, playerState.rerolls - 1);
+
+    const totals = formatTotals(playerState);
+    sendChat(SCRIPT_NAME, `${getDisplayName(playerId)} spends a reroll token for a ${kindLabel}. (${totals})`);
+  };
+
+  const announceChange = (verb, playerId, delta, recipient) => {
+    const summary = formatDelta(delta);
+    const totals = formatTotals(getOrCreatePlayerState(playerId));
+    const name = getDisplayName(playerId);
+    const message = `${verb} **${name}** — ${summary}.<br><span style="font-size: 0.9em;">${totals}</span>`;
+    whisper(recipient, message);
+  };
+
+  const formatStatusLine = (name, playerState) => {
+    return `**${name}** — ${formatTotals(playerState)}`;
+  };
+
+  const formatTotals = (playerState) => {
+    return RESOURCE_KEYS
+      .map((key) => `${RESOURCE_LABELS[key]} ${playerState[key] || 0}`)
+      .join(' | ');
+  };
+
+  const formatDelta = (delta) => {
+    return _.chain(delta)
+      .map((value, key) => `${RESOURCE_LABELS[key] || titleCase(key)} ${value >= 0 ? '+' : ''}${value}`)
+      .join(', ')
+      .value();
+  };
+
+  const titleCase = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+
+  const getOrCreatePlayerState = (playerId) => {
+    const players = state.Hoard.players;
+    if (!players[playerId]) {
+      players[playerId] = { scrip: 0, fse: 0, squares: 0, rerolls: 0 };
+    }
+    ensurePlayerStateDefaults(players[playerId]);
+    return players[playerId];
+  };
+
+  const parseResourceArgs = (args, options = {}) => {
+    const { allowZero = false } = options;
+    const values = {};
+    RESOURCE_KEYS.forEach((key) => {
+      if (args[key] !== undefined) {
+        const numeric = parseInt(args[key], 10);
+        if (!_.isNaN(numeric) && (allowZero || numeric !== 0)) {
+          values[key] = numeric;
+        }
+      }
+    });
+    return values;
+  };
+
+  const applyResourceDelta = (playerState, adjustments) => {
+    const applied = {};
+
+    _.each(adjustments, (delta, key) => {
+      if (!_.contains(RESOURCE_KEYS, key)) {
+        return;
+      }
+      const prior = playerState[key] || 0;
+      const nextValue = Math.max(0, prior + delta);
+      playerState[key] = nextValue;
+      const actualDelta = nextValue - prior;
+      if (actualDelta !== 0) {
+        applied[key] = actualDelta;
+      }
+    });
+
+    return applied;
+  };
+
+  const resolvePlayerId = (rawValue, msg, allowEmpty) => {
+    if (!rawValue) {
+      return allowEmpty ? null : msg.playerid;
+    }
+
+    const candidate = getObj('player', rawValue);
+    if (candidate) {
+      return candidate.id;
+    }
+
+    const search = rawValue.toLowerCase();
+    const matches = findObjs({ _type: 'player' }).filter((player) => player.get('displayname').toLowerCase() === search);
+
+    if (matches.length === 1) {
+      return matches[0].id;
+    }
+
+    if (matches.length > 1) {
+      whisper(msg.who, `Multiple players match "${rawValue}". Please be more specific or use the player ID.`);
+      return false;
+    }
+
+    whisper(msg.who, `No player found matching "${rawValue}".`);
+    return false;
+  };
+
+  const getDisplayName = (playerId) => {
+    const player = getObj('player', playerId);
+    if (player) {
+      return player.get('displayname');
+    }
+    return `Player ${playerId}`;
+  };
+
+  const sendHelp = (msg) => {
+    const lines = [
+      '<strong>Hoard Card Manager</strong> commands:',
+      '`!hoard status [--player "Name"]` — show currency totals.',
+      '`!hoard award --player "Name" --scrip N --fse N --squares N --rerolls N` (GM) — grant resources.',
+      '`!hoard spend --player "Name" --scrip N --fse N --squares N --rerolls N` (GM) — spend resources.',
+      '`!hoard set --player "Name" --scrip N --fse N --squares N --rerolls N` (GM) — set exact totals.',
+      '`!hoard reroll [--player "Name"] [--kind slot|die]` — consume a reroll token.'
+    ];
+    whisper(msg.who, lines.join('<br>'));
+  };
+
+  const whisper = (recipient, message) => {
+    const target = recipient || 'GM';
+    sendChat(SCRIPT_NAME, `/w "${target}" ${message}`);
+  };
+
+  on('ready', onReady);
+  on('chat:message', handleInput);
+})();


### PR DESCRIPTION
## Summary
- add repository README pointing to documentation and scripts for The Hoard Roll20 mode
- document deck structures, currencies, and API usage for the Hoard card system
- implement a Roll20 Mod script that tracks currencies and reroll tokens via chat commands

## Testing
- not run (documentation and Roll20 API script)


------
https://chatgpt.com/codex/tasks/task_e_68e1b680eba0832e830fb1c897422fe6