### PR TITLE
Add initial state and deck manager modules

### DIFF
--- a/src/modules/deckManager.js
+++ b/src/modules/deckManager.js
@@ -1,0 +1,82 @@
+// ------------------------------------------------------------
+// Deck Manager
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Handles all card pulling logic for the game.
+//   It knows how to find decks (Relics, Boons, Upgrades),
+//   draw random cards from them, apply rarity weights,
+//   and reshuffle or discard cards as needed.
+//
+//   Think of it as the dealer in a card game —
+//   it decides what cards come up next for each event.
+// ------------------------------------------------------------
+
+var DeckManager = (function () {
+
+  /** Helper: finds a deck object by name */
+  function getDeck(deckName) {
+    let deck = findObjs({ type: "deck", name: deckName })[0];
+    if (!deck) {
+      log(`Deck "${deckName}" not found!`);
+    }
+    return deck;
+  }
+
+  /** Draws a single card from a given deck */
+  function drawOne(deckName) {
+    const deck = getDeck(deckName);
+    if (!deck) return null;
+
+    // Draw the top card
+    const cards = deck.get("cards");
+    if (!cards || cards.length === 0) {
+      log(`Deck ${deckName} is empty!`);
+      return null;
+    }
+
+    const cardId = cards[0].id;
+    const card = getObj("card", cardId);
+    if (card) {
+      deck.deal(1, Campaign().get("playerspecificpages"));
+      return card;
+    }
+    return null;
+  }
+
+  /** Draws from weighted rarity decks (e.g., Common/Greater/Signature) */
+  function drawByWeight(baseName, weights) {
+    const roll = randomInteger(100) / 100;
+    let deckName = `${baseName}.Common`;
+    if (roll > weights.C && roll <= weights.C + weights.G) deckName = `${baseName}.Greater`;
+    if (roll > weights.C + weights.G) deckName = `${baseName}.Signature`;
+    return drawOne(deckName);
+  }
+
+  /** Shuffles all decks in a given category */
+  function shuffleAll(baseName, rarities) {
+    rarities.forEach(r => {
+      const d = getDeck(`${baseName}.${r}`);
+      if (d) d.shuffle();
+    });
+  }
+
+  /** Shows a menu of drawn cards (K options) */
+  function presentChoices(playerName, cards, commandPrefix) {
+    let menu = `<div style="border:1px solid #555;background:#1a1a1a;padding:5px;color:#eee">`;
+    menu += `<b>Choose one:</b><br>`;
+    cards.forEach(c => {
+      menu += `[${c.get("name")}](!${commandPrefix} ${c.id}) `;
+    });
+    menu += `</div>`;
+    sendChat("Hoard Run", `/w ${playerName} ${menu}`);
+  }
+
+  return {
+    getDeck,
+    drawOne,
+    drawByWeight,
+    shuffleAll,
+    presentChoices
+  };
+
+})();

--- a/src/modules/stateManager.js
+++ b/src/modules/stateManager.js
@@ -1,0 +1,99 @@
+// ------------------------------------------------------------
+// State Manager
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Keeps track of everything that lasts through a run —
+//   each player's currencies (Scrip, FSE, RerollTokens, Squares),
+//   what Ancestor they picked, their boons and relics,
+//   and the current room or floor they're on.
+//
+//   Think of it as the save-file for each player inside Roll20.
+//
+//   All data is stored inside Roll20's built-in `state` object,
+//   which automatically saves between sessions.
+// ------------------------------------------------------------
+
+var StateManager = (function () {
+
+  const DEFAULT_PLAYER_STATE = {
+    ancestor_id: null,
+    scrip: 0,
+    fse: 0,
+    squares: 0,
+    rerollTokens: 0,
+    boons: [],
+    relics: [],
+    currentRoom: 1,
+    corridorLength: 6
+  };
+
+  /** Initializes the global storage if it doesn't exist */
+  function init() {
+    if (!state.HoardRun) {
+      state.HoardRun = { players: {} };
+      log("HoardRun state initialized.");
+    }
+  }
+
+  /** Ensures a player entry exists */
+  function initPlayer(playerid) {
+    init();
+    if (!state.HoardRun.players[playerid]) {
+      state.HoardRun.players[playerid] = JSON.parse(JSON.stringify(DEFAULT_PLAYER_STATE));
+      log(`Created new run data for player ${playerid}`);
+    }
+    return state.HoardRun.players[playerid];
+  }
+
+  /** Retrieves a player's saved data */
+  function getPlayer(playerid) {
+    initPlayer(playerid);
+    return state.HoardRun.players[playerid];
+  }
+
+  /** Adds currency (Scrip, FSE, Squares, etc.) */
+  function addCurrency(playerid, type, amount) {
+    const p = getPlayer(playerid);
+    if (p[type] !== undefined) {
+      p[type] += amount;
+      log(`${type} +${amount} for player ${playerid}`);
+    }
+  }
+
+  /** Deducts Scrip for shop purchases */
+  function spendScrip(playerid, amount) {
+    const p = getPlayer(playerid);
+    if (p.scrip >= amount) {
+      p.scrip -= amount;
+      return true;
+    } else {
+      sendChat("Hoard Run", `/w "${getObj('player', playerid).get('_displayname')}" Not enough Scrip!`);
+      return false;
+    }
+  }
+
+  /** Clears all data (use with care!) */
+  function resetAll() {
+    state.HoardRun = { players: {} };
+    log("All HoardRun data cleared.");
+  }
+
+  /** Dumps a readable summary for GM */
+  function debugPrint(playerid) {
+    const p = getPlayer(playerid);
+    let summary = `Scrip: ${p.scrip}, FSE: ${p.fse}, Squares: ${p.squares}, RerollTokens: ${p.rerollTokens}`;
+    sendChat("Hoard Run", `/w gm ${summary}`);
+  }
+
+  // Public API
+  return {
+    init,
+    initPlayer,
+    getPlayer,
+    addCurrency,
+    spendScrip,
+    resetAll,
+    debugPrint
+  };
+
+})();


### PR DESCRIPTION
## Summary
- add a Roll20 state manager module for tracking per-player data and currency
- add a deck manager module for drawing and presenting cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c629e868832e99b628d03cd381e0