### PR TITLE
feat: add room progression and ui modules

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,15 @@
+# Hoard Run Commands
+
+## Corridor Flow
+- `!startrun` — Begin a new Hoard Run for the issuing player. Resets currencies, inventory, and room progress.
+- `!nextr room|miniboss|boss` — Advance to the next room type in the corridor and automatically award rewards.
+
+## Shops & Economy
+- `!openshop` — Summon Bing, Bang & Bongo's shop interface for purchases.
+
+## Boons
+- `!offerboons <Ancestor>` — Present boon choices tied to the specified Ancestor.
+- `!chooseboon <CardID>` — Claim a boon from the current offering.
+
+## Currency Utilities
+- `!tradeSquares scrip|fse` — Convert Squares into the specified currency reward.

--- a/src/modules/roomManager.js
+++ b/src/modules/roomManager.js
@@ -1,0 +1,164 @@
+// ------------------------------------------------------------
+// Room Manager
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Controls corridor progression in a Hoard Run.
+//   Handles room sequencing, reward payouts, miniboss/boss logic,
+//   and triggers shop access at the right times.
+//
+//   Think of it as the "dungeon crawler" engine.
+// ------------------------------------------------------------
+
+var RoomManager = (function () {
+
+  // ------------------------------------------------------------
+  // Constants (temporary until moved to config/constants.js)
+  // ------------------------------------------------------------
+  var REWARDS = {
+    room:     { scrip: 20, fse: 1 },
+    miniboss: { scrip: 20, fse: 2, squareChance: 0.5 },
+    boss:     { scrip: 40, fse: 5, squareChance: 0.5 },
+    firstClearBonusFSE: 3
+  };
+
+  // ------------------------------------------------------------
+  // Internal Helpers
+  // ------------------------------------------------------------
+
+  function getPlayerName(playerid) {
+    var player = getObj('player', playerid);
+    return player ? player.get('_displayname') : 'Player';
+  }
+
+  function sanitizeRoomType(roomType) {
+    if (roomType === 'miniboss' || roomType === 'boss') {
+      return roomType;
+    }
+    return 'room';
+  }
+
+  // ------------------------------------------------------------
+  // Core Functions
+  // ------------------------------------------------------------
+
+  /**
+   * Applies reward bundle based on room type.
+   * @param {string} playerid - Roll20 player ID.
+   * @param {'room'|'miniboss'|'boss'} type - Room reward type.
+   */
+  function applyRewards(playerid, type) {
+    var roomType = sanitizeRoomType(type);
+    var bundle = REWARDS[roomType] || REWARDS.room;
+
+    StateManager.addCurrency(playerid, 'scrip', bundle.scrip);
+    StateManager.addCurrency(playerid, 'fse', bundle.fse);
+
+    if (bundle.squareChance && Math.random() < bundle.squareChance) {
+      StateManager.addCurrency(playerid, 'squares', 1);
+      UIManager.whisper(getPlayerName(playerid), 'Treasure', '✦ You found a Square!');
+    }
+  }
+
+  /**
+   * Advances to the next room in the corridor.
+   * Triggers rewards and opens shops at milestones.
+   */
+  function advanceRoom(playerid, roomType) {
+    StateManager.initPlayer(playerid);
+    var p = StateManager.getPlayer(playerid);
+    var safeType = sanitizeRoomType(roomType);
+    var bundle = REWARDS[safeType] || REWARDS.room;
+    p.currentRoom += 1;
+
+    applyRewards(playerid, safeType);
+
+    UIManager.whisper(
+      getPlayerName(playerid),
+      'Room ' + p.currentRoom + ' Cleared',
+      '➤ +' + bundle.scrip + ' Scrip, +' + bundle.fse + ' FSE.'
+    );
+
+    if (p.currentRoom === 3) {
+      UIManager.whisper(
+        getPlayerName(playerid),
+        'Shop Available',
+        '🛒 Bing, Bang & Bongo await! Use !openshop.'
+      );
+    }
+
+    if (p.currentRoom === 5) {
+      UIManager.whisper(
+        getPlayerName(playerid),
+        'Optional Shop',
+        '🛒 Optional shop unlocked. Use !openshop if desired.'
+      );
+    }
+
+    if (safeType === 'boss' && !p.firstClearAwarded) {
+      StateManager.addCurrency(playerid, 'fse', REWARDS.firstClearBonusFSE);
+      p.firstClearAwarded = true;
+      UIManager.whisper(
+        getPlayerName(playerid),
+        'First Clear Bonus',
+        '✪ +' + REWARDS.firstClearBonusFSE + ' FSE.'
+      );
+    }
+
+    StateManager.initPlayer(playerid);
+  }
+
+  /**
+   * Starts a new corridor run (resets counters).
+   * @param {string} playerid
+   */
+  function startRun(playerid) {
+    StateManager.initPlayer(playerid);
+    var p = StateManager.getPlayer(playerid);
+    p.currentRoom = 0;
+    p.scrip = 0;
+    p.fse = 0;
+    p.squares = 0;
+    p.boons = [];
+    p.relics = [];
+    p.boonOffered = false;
+    p.firstClearAwarded = false;
+
+    UIManager.whisper(
+      getPlayerName(playerid),
+      'New Hoard Run',
+      '⚔️ A new Hoard Run begins. Enter Room 1 when ready!'
+    );
+  }
+
+  // ------------------------------------------------------------
+  // Command Registration
+  // ------------------------------------------------------------
+  function registerCommands() {
+    on('chat:message', function (msg) {
+      if (msg.type !== 'api') {
+        return;
+      }
+      var args = msg.content.split(' ');
+      var cmd = args[0];
+
+      if (cmd === '!nextr') {
+        var type = args[1] || 'room';
+        advanceRoom(msg.playerid, type);
+      }
+
+      if (cmd === '!startrun') {
+        startRun(msg.playerid);
+      }
+    });
+  }
+
+  return {
+    startRun: startRun,
+    advanceRoom: advanceRoom,
+    applyRewards: applyRewards,
+    registerCommands: registerCommands
+  };
+
+})();
+
+on('ready', RoomManager.registerCommands);

--- a/src/modules/uiManager.js
+++ b/src/modules/uiManager.js
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------
+// UI Manager
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Centralizes all chat output formatting.
+//   Lets you style messages consistently across modules.
+//   Provides simple wrappers for headers, menus, and alerts.
+//
+//   Think of it as the "front-end theme" for your Roll20 mod.
+// ------------------------------------------------------------
+
+var UIManager = (function () {
+
+  // ------------------------------------------------------------
+  // Basic Style Templates
+  // ------------------------------------------------------------
+  var COLORS = {
+    bg: '#1a1a1a',
+    border: '#555',
+    text: '#eee',
+    accent: '#c2a347'
+  };
+
+  /**
+   * Creates a bordered chat box with title and content.
+   * @param {string} title
+   * @param {string} bodyHTML
+   * @returns {string} HTML block
+   */
+  function panel(title, bodyHTML) {
+    return (
+      '<div style="border:1px solid ' + COLORS.border +
+      ';background:' + COLORS.bg +
+      ';color:' + COLORS.text +
+      ';padding:6px;margin:4px 0;">' +
+      '<b style="color:' + COLORS.accent + '">' + title + '</b><br>' +
+      bodyHTML + '</div>'
+    );
+  }
+
+  /**
+   * Creates a list of buttons.
+   * @param {Array<{label:string,command:string}>} buttons
+   * @returns {string}
+   */
+  function buttons(buttons) {
+    return buttons.map(function (b) {
+      return '[' + b.label + '](' + b.command + ')';
+    }).join(' ');
+  }
+
+  /**
+   * Sends a styled whisper to a player.
+   * @param {string} playerName
+   * @param {string} title
+   * @param {string} bodyHTML
+   */
+  function whisper(playerName, title, bodyHTML) {
+    sendChat('Hoard Run', '/w ' + playerName + ' ' + panel(title, bodyHTML));
+  }
+
+  /**
+   * Broadcasts a system message to the GM only.
+   * @param {string} msg
+   */
+  function gmLog(msg) {
+    sendChat('Hoard Run', '/w gm ' + msg);
+  }
+
+  // ------------------------------------------------------------
+  // Public API
+  // ------------------------------------------------------------
+  return {
+    panel: panel,
+    buttons: buttons,
+    whisper: whisper,
+    gmLog: gmLog
+  };
+
+})();


### PR DESCRIPTION
## Summary
- add a UIManager module that standardizes chat panels, buttons, and whispers
- implement RoomManager to manage corridor progression, rewards, and milestone shops
- document available Hoard Run chat commands in docs/COMMANDS.md

## Testing
- not run (Roll20 sandbox environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1cc04f790832e8764b9631e083365