### PR TITLE
feat: auto boon offers after room clears

### DIFF
--- a/src/modules/roomManager.js
+++ b/src/modules/roomManager.js
@@ -68,30 +68,50 @@ var RoomManager = (function () {
     var p = StateManager.getPlayer(playerid);
     var safeType = sanitizeRoomType(roomType);
     var bundle = REWARDS[safeType] || REWARDS.room;
+    var playerName = getPlayerName(playerid);
     p.currentRoom += 1;
 
     applyRewards(playerid, safeType);
 
     UIManager.whisper(
-      getPlayerName(playerid),
+      playerName,
       'Room ' + p.currentRoom + ' Cleared',
       '➤ +' + bundle.scrip + ' Scrip, +' + bundle.fse + ' FSE.'
     );
 
+    try {
+      if (typeof BoonManager !== 'undefined' && typeof BoonManager.offerBoons === 'function') {
+        if (safeType === 'room' || safeType === 'miniboss') {
+          BoonManager.offerBoons(playerid);
+          UIManager.whisper(
+            playerName,
+            'Boon Offer',
+            '🪄 A mysterious force offers you a new Boon...'
+          );
+        }
+      } else {
+        UIManager.gmLog('BoonManager not available or missing offerBoons().');
+      }
+    } catch (err) {
+      UIManager.gmLog('Error offering Boons: ' + err);
+    }
+
     if (p.currentRoom === 3) {
       UIManager.whisper(
-        getPlayerName(playerid),
+        playerName,
         'Shop Available',
         '🛒 Bing, Bang & Bongo await! Use !openshop.'
       );
+      UIManager.gmLog('Shop available after Room 3. Move to Shop page to open.');
     }
 
     if (p.currentRoom === 5) {
       UIManager.whisper(
-        getPlayerName(playerid),
+        playerName,
         'Optional Shop',
         '🛒 Optional shop unlocked. Use !openshop if desired.'
       );
+      UIManager.gmLog('Optional shop available after Room 5. Move to Shop page to open.');
     }
 
     if (safeType === 'boss' && !p.firstClearAwarded) {


### PR DESCRIPTION
## Summary
- reuse the cached player name in roomManager to avoid repeated lookups
- automatically trigger BoonManager offers after normal and miniboss rooms with player messaging
- log shop availability to the GM alongside existing player whispers for rooms 3 and 5

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d9d4d81c832e82d3894d3fe9d1f4