### PR TITLE
fix: disable initialization guard for debugging

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,10 +36,11 @@ on('ready', function () {
   // ------------------------------------------------------------
   // Prevent duplicate initialization
   // ------------------------------------------------------------
-  if (state.HoardRun.initialized) {
-    log('[Hoard Run] Sandbox reloaded — modules already initialized.');
-    return;
-  }
+  // Temporarily disabled guard to allow forced reinitialization during debugging.
+  // if (state.HoardRun.initialized) {
+  //   log('[Hoard Run] Sandbox reloaded — modules already initialized.');
+  //   return;
+  // }
 
   log('=== Hoard Run ' + VERSION + ' initializing... ===');
 


### PR DESCRIPTION
## Summary
- comment out the initialization guard in main.js to permit reinitializing the Hoard Run modules after a sandbox reload
- leave a note explaining that the guard is temporarily disabled for debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1f43da5fc832eae28b5fe39a7f0a6