### PR TITLE
Add GM-driven run flow manager for Hoard Run start

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -2,7 +2,10 @@
 
 ## Corridor Flow
 - `!startrun` — Begin a new Hoard Run for the issuing player. Resets currencies, inventory, and room progress.
-- `!nextr room|miniboss|boss` — Advance to the next room type in the corridor and automatically award rewards.
+- `!selectweapon <Weapon>` — Lock in the party's starting focus (Staff, Orb, Greataxe, Rapier, Bow).
+- `!selectancestor <Name>` — Bind the Ancestor boon package tied to the chosen weapon.
+- `!nextroom` — Advance the scripted Hoard Run flow (ancestor prompts, free boon phase, room counter).
+- `!nextr room|miniboss|boss` — Advance to the next room type in the legacy corridor system and award rewards.
 
 ## Shops & Economy
 - `!openshop` — Summon Bing, Bang & Bongo's shop interface for purchases.

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@
 // ------------------------------------------------------------
 
 on('ready', function () {
-  var VERSION = 'v1.0.1';
+  var VERSION = 'v1.1.0';
   var MODULES = [
     'StateManager',
     'DeckManager',
@@ -17,6 +17,7 @@ on('ready', function () {
     'BoonManager',
     'ShopManager',
     'RoomManager',
+    'RunFlowManager',
     'EventManager',
     'DevTools'
   ];
@@ -43,55 +44,6 @@ on('ready', function () {
   // }
 
   log('=== Hoard Run ' + VERSION + ' initializing... ===');
-
-  // === Hoard Run Command Listener ===
-  on('chat:message', function (msg) {
-    if (msg.type !== 'api') {
-      return;
-    }
-
-    var args = msg.content.trim().split(/\s+/);
-    var command = args.shift().toLowerCase();
-
-    // --- !startrun ---
-    if (command === '!startrun') {
-      if (!state.HoardRun) state.HoardRun = {};
-      state.HoardRun.activeRun = {
-        currentRoom: 1,
-        scrip: 0,
-        fse: 0,
-        rerollTokens: 0,
-        squares: 0,
-        ancestor: 'Azuren',
-        started: true
-      };
-
-      sendChat('Hoard Run', '/w gm 🏁 <b>Run started!</b><br>Room 1 ready.<br>Scrip: 0 | FSE: 0 | Ancestor: Azuren');
-      log('[Hoard Run] Run started.');
-    }
-
-    // --- !nextroom ---
-    if (command === '!nextroom') {
-      var hasRun = state.HoardRun && state.HoardRun.activeRun && state.HoardRun.activeRun.started;
-      if (!hasRun) {
-        sendChat('Hoard Run', '/w gm ⚠️ No active run. Use !startrun first.');
-        return;
-      }
-
-      var run = state.HoardRun.activeRun;
-      run.currentRoom += 1;
-      run.scrip += 20;
-      run.fse += 1;
-
-      sendChat('Hoard Run', '/w gm ▶️ Advanced to Room ' + run.currentRoom + '.<br>+20 Scrip, +1 FSE<br>Total — Scrip: ' + run.scrip + ', FSE: ' + run.fse);
-    }
-
-    // --- !debugstate ---
-    if (command === '!debugstate') {
-      sendChat('Hoard Run', '/w gm <pre>' + JSON.stringify(state.HoardRun, null, 2) + '</pre>');
-      log('[Hoard Run] State dump sent.');
-    }
-  });
 
   // ------------------------------------------------------------
   // Register all modules if available
@@ -129,7 +81,10 @@ on('ready', function () {
     'Modules loaded: ' + MODULES.join(', ') + '.<br><br>' +
     '<u>Commands:</u><br>' +
     '• <b>!startrun</b> – Begin a new Hoard Run<br>' +
-    '• <b>!nextr room|miniboss|boss</b> – Advance to next room<br>' +
+    '• <b>!selectweapon [Weapon]</b> – Lock in starting focus<br>' +
+    '• <b>!selectancestor [Name]</b> – Bind an Ancestor blessing<br>' +
+    '• <b>!nextroom</b> – Progress core Hoard Run flow<br>' +
+    '• <b>!nextr room|miniboss|boss</b> – Legacy room advancement<br>' +
     '• <b>!openshop</b> – Open Bing, Bang & Bongo Shop<br>' +
     '• <b>!offerboons [Ancestor]</b> – Offer boon choices<br>' +
     '• <b>!chooseboon [CardID]</b> – Choose a boon<br>' +

--- a/src/modules/devTools.js
+++ b/src/modules/devTools.js
@@ -18,6 +18,9 @@ var DevTools = (function () {
   function resetState() {
     delete state.HoardRun;
     state.HoardRun = { players: {}, version: 'dev' };
+    if (typeof RunFlowManager !== 'undefined' && typeof RunFlowManager.resetRunState === 'function') {
+      RunFlowManager.resetRunState();
+    }
     sendChat('Hoard Run', '/w gm ⚙️ HoardRun state has been reset.');
   }
 

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -91,6 +91,18 @@ var RunFlowManager = (function () {
     return rendered;
   }
 
+  function promptAncestorSelection(run) {
+    var weaponAncestors = (ANCESTOR_SETS[run.weapon] || []).map(function (a) {
+      return { label: 'Select ' + a, command: '!selectancestor "' + a + '"' };
+    });
+
+    var body = 'Choose your Ancestor (weapon: <b>' + run.weapon + '</b>):<br><br>' +
+      formatButtons(weaponAncestors);
+
+    sendDirect('Ancestor Selection', body);
+    log('[RunFlow] Awaiting ancestor selection for ' + run.weapon + '.');
+  }
+
   function sendDirect(title, bodyHTML) {
     sendChat('Hoard Run', '/direct ' + formatPanel(title, bodyHTML));
   }
@@ -236,18 +248,15 @@ var RunFlowManager = (function () {
       return;
     }
 
+    if (run.currentRoom === 2 && !run.ancestor) {
+      promptAncestorSelection(run);
+      return;
+    }
+
     run.currentRoom += 1;
 
     if (run.currentRoom === 2 && !run.ancestor) {
-      var weaponAncestors = (ANCESTOR_SETS[run.weapon] || []).map(function (a) {
-        return { label: 'Select ' + a, command: '!selectancestor "' + a + '"' };
-      });
-
-      var body = 'Choose your Ancestor (weapon: <b>' + run.weapon + '</b>):<br><br>' +
-        formatButtons(weaponAncestors);
-
-      sendDirect('Ancestor Selection', body);
-      log('[RunFlow] Awaiting ancestor selection for ' + run.weapon + '.');
+      promptAncestorSelection(run);
       return;
     }
 

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -1,0 +1,313 @@
+// ------------------------------------------------------------
+// Run Flow Manager
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Directs the opening beats of a Hoard Run campaign.
+//   Handles starting the run, weapon selection, ancestor binding,
+//   the first free boon phase, and steady room progression.
+//   Designed to complement existing managers (Boon/Event/Relic).
+// ------------------------------------------------------------
+
+var RunFlowManager = (function () {
+
+  var VERSION = '1.1.0';
+  var isRegistered = false;
+
+  var DEFAULT_RUN_STATE = {
+    currentRoom: 0,
+    weapon: null,
+    ancestor: null,
+    freeBoonUsed: false,
+    scrip: 0,
+    fse: 0,
+    rerollTokens: 0,
+    squares: 0,
+    started: false
+  };
+
+  var WEAPONS = ['Staff', 'Orb', 'Greataxe', 'Rapier', 'Bow'];
+
+  var ANCESTOR_SETS = {
+    Staff: ['Azuren', 'Sutra Vayla'],
+    Orb: ['Sutra Vayla', 'Seraphine Emberwright'],
+    Greataxe: ['Vladren Moroi', 'Morvox, Tiny Tyrant'],
+    Rapier: ['Lian Veilbinder', 'Vladren Moroi'],
+    Bow: ['Azuren', 'Lian Veilbinder']
+  };
+
+  // ------------------------------------------------------------
+  // Internal Helpers
+  // ------------------------------------------------------------
+
+  function ensureState() {
+    if (!state.HoardRun) {
+      state.HoardRun = {};
+    }
+    if (!state.HoardRun.runFlow) {
+      state.HoardRun.runFlow = clone(DEFAULT_RUN_STATE);
+      log('[RunFlow] Initialized run flow state.');
+    }
+  }
+
+  function clone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function getRun() {
+    ensureState();
+    return state.HoardRun.runFlow;
+  }
+
+  function resetRunState() {
+    state.HoardRun.runFlow = clone(DEFAULT_RUN_STATE);
+    log('[RunFlow] Run state reset.');
+    return state.HoardRun.runFlow;
+  }
+
+  function isGM(playerid) {
+    if (typeof playerIsGM === 'function') {
+      return playerIsGM(playerid);
+    }
+    return true;
+  }
+
+  function formatPanel(title, bodyHTML) {
+    if (typeof UIManager !== 'undefined' && typeof UIManager.panel === 'function') {
+      return UIManager.panel(title, bodyHTML);
+    }
+    return '<div style="border:1px solid #666;padding:5px;background:#111;color:#EEE;">' +
+      '<b>' + title + '</b><br>' + bodyHTML + '</div>';
+  }
+
+  function formatButtons(buttons) {
+    var rendered;
+    if (typeof UIManager !== 'undefined' && typeof UIManager.buttons === 'function') {
+      rendered = UIManager.buttons(buttons);
+      return rendered.replace(/\)\s*\[/g, ')<br>[');
+    }
+    rendered = buttons.map(function (b) {
+      return '[' + b.label + '](' + b.command + ')';
+    }).join('<br>');
+    return rendered;
+  }
+
+  function sendDirect(title, bodyHTML) {
+    sendChat('Hoard Run', '/direct ' + formatPanel(title, bodyHTML));
+  }
+
+  function whisperGM(title, bodyHTML) {
+    sendChat('Hoard Run', '/w gm ' + formatPanel(title, bodyHTML));
+  }
+
+  function sanitizeWeapon(arg) {
+    if (!arg) {
+      return null;
+    }
+    var trimmed = arg.trim();
+    if (!trimmed) {
+      return null;
+    }
+    var normalized = trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+    var i;
+    for (i = 0; i < WEAPONS.length; i += 1) {
+      if (WEAPONS[i].toLowerCase() === normalized.toLowerCase()) {
+        return WEAPONS[i];
+      }
+    }
+    return null;
+  }
+
+  function grantFreeBoons(run) {
+    run.freeBoonUsed = true;
+    run.rerollTokens += 1;
+    sendDirect('Free Boon Phase',
+      '🎁 You gain <b>2 free Boons</b> and <b>+1 Reroll Token</b>.<br><br>' +
+      'Use <code>!offerboons ' + run.ancestor + '</code> to choose your starting boons.'
+    );
+  }
+
+  // ------------------------------------------------------------
+  // Core Actions
+  // ------------------------------------------------------------
+
+  function handleStartRun(playerid) {
+    if (!isGM(playerid)) {
+      return;
+    }
+
+    var run = resetRunState();
+    run.started = true;
+
+    var body = 'Choose your weapon to begin your journey:<br><br>' +
+      formatButtons([
+        { label: 'Select Staff', command: '!selectweapon Staff' },
+        { label: 'Select Orb', command: '!selectweapon Orb' },
+        { label: 'Select Greataxe', command: '!selectweapon Greataxe' },
+        { label: 'Select Rapier', command: '!selectweapon Rapier' },
+        { label: 'Select Bow', command: '!selectweapon Bow' }
+      ]);
+
+    sendDirect('Welcome to the Hoard Run', body);
+    log('[RunFlow] Run started. Awaiting weapon selection.');
+  }
+
+  function handleSelectWeapon(playerid, arg) {
+    if (!isGM(playerid)) {
+      return;
+    }
+
+    var run = getRun();
+    if (!run.started) {
+      whisperGM('Weapon Selection', '⚠️ No active run. Use <b>!startrun</b> first.');
+      return;
+    }
+
+    var weapon = sanitizeWeapon(arg);
+    if (!weapon) {
+      whisperGM('Weapon Selection', '⚠️ Invalid weapon: ' + (arg || '(none)'));
+      return;
+    }
+
+    run.weapon = weapon;
+    run.currentRoom = 1;
+
+    sendDirect('Weapon Chosen', '🗡️ Weapon locked: <b>' + weapon + '</b>.<br>Prepare for your first encounter!<br><br>' +
+      'Entering <b>Room 1</b>...');
+    log('[RunFlow] Weapon selected: ' + weapon);
+  }
+
+  function handleSelectAncestor(playerid, arg) {
+    if (!isGM(playerid)) {
+      return;
+    }
+
+    var run = getRun();
+    if (!run.started || !run.weapon) {
+      whisperGM('Ancestor Selection', '⚠️ Start a run and choose a weapon first.');
+      return;
+    }
+
+    var name = (arg || '').trim().replace(/^"|"$/g, '');
+    if (!name) {
+      whisperGM('Ancestor Selection', '⚠️ Provide an ancestor name.');
+      return;
+    }
+
+    var options = ANCESTOR_SETS[run.weapon] || [];
+    var isValid = false;
+    var i;
+    for (i = 0; i < options.length; i += 1) {
+      if (options[i].toLowerCase() === name.toLowerCase()) {
+        name = options[i];
+        isValid = true;
+        break;
+      }
+    }
+
+    if (!isValid) {
+      whisperGM('Ancestor Selection', '⚠️ ' + name + ' is not available for the ' + run.weapon + '.');
+      return;
+    }
+
+    run.ancestor = name;
+
+    sendDirect('Ancestor Chosen', '🌟 Ancestor blessing secured: <b>' + name + '</b>.<br>' +
+      'When you enter Room 2, you will gain 2 free Boons and +1 Reroll token.');
+    log('[RunFlow] Ancestor selected: ' + name);
+
+    if (run.currentRoom === 2 && !run.freeBoonUsed) {
+      grantFreeBoons(run);
+    }
+  }
+
+  function handleNextRoom(playerid) {
+    if (!isGM(playerid)) {
+      return;
+    }
+
+    var run = getRun();
+    if (!run.started) {
+      whisperGM('Room Progression', '⚠️ No active run. Use <b>!startrun</b> first.');
+      return;
+    }
+
+    if (!run.weapon) {
+      whisperGM('Room Progression', '⚠️ Choose a weapon before advancing.');
+      return;
+    }
+
+    run.currentRoom += 1;
+
+    if (run.currentRoom === 2 && !run.ancestor) {
+      var weaponAncestors = (ANCESTOR_SETS[run.weapon] || []).map(function (a) {
+        return { label: 'Select ' + a, command: '!selectancestor "' + a + '"' };
+      });
+
+      var body = 'Choose your Ancestor (weapon: <b>' + run.weapon + '</b>):<br><br>' +
+        formatButtons(weaponAncestors);
+
+      sendDirect('Ancestor Selection', body);
+      log('[RunFlow] Awaiting ancestor selection for ' + run.weapon + '.');
+      return;
+    }
+
+    if (run.currentRoom === 2 && run.ancestor && !run.freeBoonUsed) {
+      grantFreeBoons(run);
+      return;
+    }
+
+    sendDirect('Room Progression', '▶️ Advanced to <b>Room ' + run.currentRoom + '</b>.');
+    log('[RunFlow] Advanced to room ' + run.currentRoom + '.');
+  }
+
+  // ------------------------------------------------------------
+  // Event Handling
+  // ------------------------------------------------------------
+
+  function handleMessage(msg) {
+    if (msg.type !== 'api') {
+      return;
+    }
+
+    var content = (msg.content || '').trim();
+    if (!content) {
+      return;
+    }
+
+    var spaceIdx = content.indexOf(' ');
+    var command = spaceIdx === -1 ? content : content.slice(0, spaceIdx);
+    var argString = spaceIdx === -1 ? '' : content.slice(spaceIdx + 1);
+
+    switch (command.toLowerCase()) {
+      case '!startrun':
+        handleStartRun(msg.playerid);
+        break;
+      case '!selectweapon':
+        handleSelectWeapon(msg.playerid, argString);
+        break;
+      case '!selectancestor':
+        handleSelectAncestor(msg.playerid, argString);
+        break;
+      case '!nextroom':
+        handleNextRoom(msg.playerid);
+        break;
+    }
+  }
+
+  function register() {
+    if (isRegistered) {
+      return;
+    }
+    ensureState();
+    on('chat:message', handleMessage);
+    log('=== Run Flow Manager ' + VERSION + ' ready ===');
+    isRegistered = true;
+  }
+
+  return {
+    register: register,
+    resetRunState: resetRunState,
+    getRunState: getRun
+  };
+
+})();


### PR DESCRIPTION
## Summary
- add a RunFlowManager module that drives the Hoard Run opening flow (start, weapon selection, ancestor binding, free boon phase, room advancement)
- register the new manager during bootstrap and refresh the GM command list documentation
- ensure DevTools reset hooks back into the new run flow state tracker and document the new chat commands

## Testing
- not run (Roll20 API sandbox only)


------
https://chatgpt.com/codex/tasks/task_e_68e1f82926f0832e9fcfceb8147f5131