### PR TITLE
fix: render roll20 api command buttons

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -83,10 +83,11 @@ var RunFlowManager = (function () {
     var rendered;
     if (typeof UIManager !== 'undefined' && typeof UIManager.buttons === 'function') {
       rendered = UIManager.buttons(buttons);
-      return rendered.replace(/\)\s*\[/g, ')<br>[');
+      return rendered;
     }
     rendered = buttons.map(function (b) {
-      return '[' + b.label + '](' + b.command + ')';
+      var command = (b.command || '').replace(/^!/, '');
+      return '[' + b.label + '](!' + command + ')';
     }).join('<br>');
     return rendered;
   }

--- a/src/modules/uiManager.js
+++ b/src/modules/uiManager.js
@@ -45,8 +45,9 @@ var UIManager = (function () {
    */
   function buttons(buttons) {
     return buttons.map(function (b) {
-      return '[' + b.label + '](' + b.command + ')';
-    }).join(' ');
+      var command = (b.command || '').replace(/^!/, '');
+      return '[' + b.label + '](!' + command + ')';
+    }).join('<br>');
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure UI and run flow button helpers emit Roll20-compatible API command links
- strip redundant leading bangs from commands and render buttons on separate lines for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20bb0f86c832ea7ebd701d12cd14e