### PR TITLE
fix: ensure roll20 buttons render as commands

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -75,20 +75,16 @@ var RunFlowManager = (function () {
     if (typeof UIManager !== 'undefined' && typeof UIManager.panel === 'function') {
       return UIManager.panel(title, bodyHTML);
     }
-    return '<div style="border:1px solid #666;padding:5px;background:#111;color:#EEE;">' +
-      '<b>' + title + '</b><br>' + bodyHTML + '</div>';
+    return '**' + title + '**\n' + bodyHTML;
   }
 
   function formatButtons(buttons) {
-    var rendered;
     if (typeof UIManager !== 'undefined' && typeof UIManager.buttons === 'function') {
-      rendered = UIManager.buttons(buttons);
-      return rendered.replace(/\)\s*\[/g, ')<br>[');
+      return UIManager.buttons(buttons);
     }
-    rendered = buttons.map(function (b) {
-      return '[' + b.label + '](' + b.command + ')';
+    return buttons.map(function (b) {
+      return '[' + b.label + '](!' + (b.command || '').replace(/^!/, '') + ')';
     }).join('<br>');
-    return rendered;
   }
 
   function promptAncestorSelection(run) {

--- a/src/modules/uiManager.js
+++ b/src/modules/uiManager.js
@@ -28,14 +28,7 @@ var UIManager = (function () {
    * @returns {string} HTML block
    */
   function panel(title, bodyHTML) {
-    return (
-      '<div style="border:1px solid ' + COLORS.border +
-      ';background:' + COLORS.bg +
-      ';color:' + COLORS.text +
-      ';padding:6px;margin:4px 0;">' +
-      '<b style="color:' + COLORS.accent + '">' + title + '</b><br>' +
-      bodyHTML + '</div>'
-    );
+    return '**' + title + '**\n' + bodyHTML;
   }
 
   /**
@@ -45,8 +38,8 @@ var UIManager = (function () {
    */
   function buttons(buttons) {
     return buttons.map(function (b) {
-      return '[' + b.label + '](' + b.command + ')';
-    }).join(' ');
+      return '[' + b.label + '](!' + (b.command || '').replace(/^!/, '') + ')';
+    }).join('<br>');
   }
 
   /**


### PR DESCRIPTION
## Summary
- update UI button formatter to emit Roll20 command syntax without extra markup
- adjust panel helper fallback to use markdown so command links remain clickable in /direct output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e20bb0f86c832ea7ebd701d12cd14e