### PR TITLE
Fix ancestor selection command encoding

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -91,7 +91,9 @@ var RunFlowManager = (function () {
 
   function promptAncestorSelection(run) {
     var weaponAncestors = (ANCESTOR_SETS[run.weapon] || []).map(function (a) {
-      return { label: 'Select ' + a, command: '!selectancestor "' + a + '"' };
+      // encode spaces so Roll20 buttons can handle multi-word names
+      var safeName = a.replace(/\s+/g, '_');
+      return { label: 'Select ' + a, command: '!selectancestor ' + safeName };
     });
 
     var body = 'Choose your Ancestor (weapon: <b>' + run.weapon + '</b>):<br><br>' +
@@ -197,7 +199,8 @@ var RunFlowManager = (function () {
       return;
     }
 
-    var name = (arg || '').trim().replace(/^"|"$/g, '');
+    var name = (arg || '').trim().replace(/_/g, ' ');
+    log('[RunFlow] Ancestor command arg: ' + name);
     if (!name) {
       whisperGM('Ancestor Selection', '⚠️ Provide an ancestor name.');
       return;


### PR DESCRIPTION
## Summary
- ensure ancestor selection buttons encode spaces for Roll20 commands
- decode underscores and log ancestor commands when handling selection

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e210153b94832ea6be768fa445d29c