### PR TITLE
feat: add ancestor data loader

### DIFF
--- a/src/modules/ancestorDataLoader.js
+++ b/src/modules/ancestorDataLoader.js
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------
+// Ancestor Data Loader
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Stores flavor information for each Ancestor inline so the
+//   Roll20 sandbox can serve quick lookups without external files.
+//   Provides a simple helper to fetch an Ancestor's title and
+//   summary for use in chat output and UI prompts.
+// ------------------------------------------------------------
+
+var AncestorDataLoader = (function () {
+
+  var AncestorData = {
+    'Azuren': {
+      title: 'The Stormheart',
+      summary: 'Master of wind and storm. Empowers mobility, deflection, and ranged control.'
+    },
+    'Sutra Vayla': {
+      title: 'The Timebinder',
+      summary: 'Chronomancer who manipulates tempo and shields allies from fate.'
+    },
+    'Seraphine Emberwright': {
+      title: 'The Forgelight',
+      summary: 'Radiant artist who channels flame into healing, renewal, and creative power.'
+    },
+    'Vladren Moroi': {
+      title: 'The Blood Regent',
+      summary: 'Vampiric tactician who thrives on sacrifice and relentless aggression.'
+    },
+    'Lian Veilbinder': {
+      title: 'The Duelist',
+      summary: 'Weaver of illusions and blade, combining elegance with deadly precision.'
+    },
+    'Morvox, Tiny Tyrant': {
+      title: 'The Miniature Monarch',
+      summary: 'Small body, massive ego. Commands minions, chaos, and unearned confidence.'
+    }
+  };
+
+  on('ready', function () {
+    log('[AncestorDataLoader] Loaded ' + Object.keys(AncestorData).length + ' ancestors.');
+  });
+
+  return {
+    get: function (name) {
+      return AncestorData[name];
+    }
+  };
+
+})();

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -224,6 +224,13 @@ var RunFlowManager = (function () {
 
     run.ancestor = name;
 
+    var info = typeof AncestorDataLoader !== 'undefined' ? AncestorDataLoader.get(name) : null;
+    if (info) {
+      sendChat('Hoard Run', '/w gm <b>' + name + ' — ' + info.title + '</b><br>' + info.summary);
+    } else {
+      sendChat('Hoard Run', '/w gm No info found for ' + name + '.');
+    }
+
     sendDirect('Ancestor Chosen', '🌟 Ancestor blessing secured: <b>' + name + '</b>.<br>' +
       'When you enter Room 2, you will gain 2 free Boons and +1 Reroll token.');
     log('[RunFlow] Ancestor selected: ' + name);


### PR DESCRIPTION
## Summary
- add an inline ancestor data loader to expose titles and summaries in the sandbox
- whisper ancestor details to the GM when an ancestor is selected during a run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21411dd6c832e9e6762ea785461cf