### PR TITLE
Fix: draw boons from stored ancestor decks

### DIFF
--- a/src/modules/boonManager.js
+++ b/src/modules/boonManager.js
@@ -25,6 +25,13 @@ var BoonManager = (function () {
   };
 
   var OFFER_COUNT = 3;
+  var _pendingChoices = {};
+
+  // Canonical ancestor key: matches BoonDataLoader (Azuren, SutraVayla, VladrenMoroi, LianVeilbinder, Morvox, SeraphineEmberwright)
+  function canonAncestor(name) {
+    // remove all non-alphanumerics, no underscores
+    return (name || '').replace(/[^A-Za-z0-9]/g, '');
+  }
 
   /** Returns the Roll20 display name (quoted for whispers) */
   function getPlayerName(playerid) {
@@ -35,33 +42,73 @@ var BoonManager = (function () {
     return '"Unknown"';
   }
 
-  /** Determines the ancestor deck path */
-  function getDeckBase(ancestor) {
-    var active = ancestor || 'Default';
-    return 'Boons.' + active;
+  function pickRarity(weights) {
+    var r = Math.random();
+    if (r < weights.C) {
+      return 'Common';
+    }
+    if (r < weights.C + weights.G) {
+      return 'Greater';
+    }
+    return 'Signature';
   }
 
-  /** Draws weighted boon cards from ancestor deck */
   function drawBoons(ancestor) {
-    if (typeof DeckManager === 'undefined' || typeof DeckManager.drawByWeight !== 'function') {
-      if (typeof UIManager !== 'undefined' && typeof UIManager.gmLog === 'function') {
-        UIManager.gmLog('BoonManager: DeckManager.drawByWeight() not available.');
-      } else {
-        gmSay('BoonManager: DeckManager.drawByWeight() not available.');
-      }
+    var decksRoot = (state.HoardRun && state.HoardRun.boons) || {};
+    var key = canonAncestor(ancestor);
+    var deck = decksRoot[key];
+    if (!deck) {
+      gmSay('⚠️ No boon deck found for "' + ancestor + '" (key: ' + key + ').');
       return [];
     }
+    var pools = {
+      Common:    (deck.Common    || []).slice(),
+      Greater:   (deck.Greater   || []).slice(),
+      Signature: (deck.Signature || []).slice()
+    };
 
-    var cards = [];
-    var base = getDeckBase(ancestor);
+    var picks = [];
     for (var i = 0; i < OFFER_COUNT; i += 1) {
-      var card = DeckManager.drawByWeight(base, RARITY_WEIGHTS);
-      if (!card) {
+      var rarity = pickRarity(RARITY_WEIGHTS);
+      var order = rarity === 'Common' ? ['Common', 'Greater', 'Signature']
+                 : rarity === 'Greater' ? ['Greater', 'Common', 'Signature']
+                 : ['Signature', 'Greater', 'Common'];
+
+      var chosen = null;
+      for (var j = 0; j < order.length; j += 1) {
+        var pool = pools[order[j]];
+        if (pool && pool.length) {
+          var idx = Math.floor(Math.random() * pool.length);
+          var source = pool.splice(idx, 1)[0];
+          if (!source) {
+            continue;
+          }
+          chosen = JSON.parse(JSON.stringify(source));
+          chosen._rarity = order[j];
+          chosen._rarityCode = order[j].charAt(0);
+          chosen._ancestor = key;
+          chosen._ancestorName = ancestor;
+          chosen.get = function (prop) {
+            if (prop === 'name') {
+              return this.name;
+            }
+            if (prop === 'notes') {
+              return this.text_in_run || '';
+            }
+            if (prop === 'gmnotes') {
+              return JSON.stringify(this);
+            }
+            return this[prop];
+          };
+          break;
+        }
+      }
+      if (!chosen) {
         break;
       }
-      cards.push(card);
+      picks.push(chosen);
     }
-    return cards;
+    return picks;
   }
 
   /** Builds a friendly reminder about boon pricing */
@@ -70,24 +117,28 @@ var BoonManager = (function () {
   }
 
   /** Offers boon choices to the specified player */
-  function offerBoons(playerid, ancestor) {
+  function offerBoons(playerid, ancestorArg) {
     StateManager.initPlayer(playerid);
 
-    var name = getPlayerName(playerid);
-    var ps = StateManager.getPlayer(playerid);
-    var chosenAncestor = ancestor || ps.ancestor_id || 'Default';
+    var ps = StateManager.getPlayer(playerid) || {};
+    var chosenAncestor = ancestorArg && ancestorArg.trim()
+        ? ancestorArg.replace(/_/g, ' ')
+        : (ps.ancestor_id || (state.HoardRun && state.HoardRun.runFlow && state.HoardRun.runFlow.ancestor) || 'Azuren');
 
     var cards = drawBoons(chosenAncestor);
     if (!cards.length) {
-      if (typeof UIManager !== 'undefined' && typeof UIManager.gmLog === 'function') {
-        UIManager.gmLog('⚠️ No boon cards were drawn from ' + getDeckBase(chosenAncestor) + '.');
-      } else {
-        gmSay('⚠️ No boon cards were drawn from ' + getDeckBase(chosenAncestor) + '.');
-      }
+      gmSay('⚠️ No boon cards were drawn from ' + canonAncestor(chosenAncestor) + '.');
       return;
     }
 
-    DeckManager.presentChoices(name, cards, 'chooseboon');
+    _pendingChoices[playerid] = cards;
+
+    var name = getPlayerName(playerid);
+    if (DeckManager && DeckManager.presentChoices) {
+      DeckManager.presentChoices(name, cards, 'chooseboon');
+    } else {
+      gmSay('⚠️ DeckManager.presentChoices not available; implement inline rendering here.');
+    }
 
     if (typeof UIManager !== 'undefined' && typeof UIManager.whisper === 'function') {
       UIManager.whisper(name, 'Ancestor Boons', 'Choose one boon from the menu above.<br>' + buildPricingNote());
@@ -96,56 +147,42 @@ var BoonManager = (function () {
     }
   }
 
-  /** Maps deck name into rarity shorthand */
-  function getRarityFromDeck(deckName) {
-    if (!deckName) {
-      return 'C';
-    }
-    var lower = deckName.toLowerCase();
-    if (lower.indexOf('signature') !== -1) {
-      return 'S';
-    }
-    if (lower.indexOf('greater') !== -1) {
-      return 'G';
-    }
-    return 'C';
-  }
-
-  /** Attempts to parse ancestor from deck path */
-  function getAncestorFromDeck(deckName) {
-    if (!deckName) {
-      return 'Unknown';
-    }
-    var parts = deckName.split('.');
-    if (parts.length >= 2) {
-      return parts[1];
-    }
-    return deckName;
-  }
-
   /** Handles the player selecting a boon */
   function chooseBoon(playerid, cardId) {
     if (!cardId) {
       return;
     }
 
-    var card = getObj('card', cardId);
-    if (!card) {
-      if (typeof UIManager !== 'undefined' && typeof UIManager.gmLog === 'function') {
-        UIManager.gmLog('BoonManager: Invalid card id ' + cardId + '.');
-      } else {
-        gmSay('BoonManager: Invalid card id ' + cardId + '.');
+    var pending = _pendingChoices[playerid] || [];
+    var selectedIndex = -1;
+    var card = null;
+
+    for (var k = 0; k < pending.length; k += 1) {
+      if ((pending[k].id || '') === cardId) {
+        selectedIndex = k;
+        card = pending[k];
+        break;
       }
+    }
+
+    if (!card) {
+      gmSay('BoonManager: Invalid card id ' + cardId + '.');
       return;
     }
 
-    var deck = getObj('deck', card.get('deckid'));
-    var deckName = deck ? deck.get('name') : '';
-    var rarity = getRarityFromDeck(deckName);
-    var cost = RARITY_PRICES[rarity] || RARITY_PRICES.C;
+    var rarityName = card._rarity || card.rarity || 'Common';
+    var rarityCode = (card._rarityCode || rarityName.charAt(0) || 'C').toUpperCase();
+    var cost = RARITY_PRICES[rarityCode] || RARITY_PRICES.C;
 
     if (!StateManager.spendScrip(playerid, cost)) {
       return;
+    }
+
+    pending.splice(selectedIndex, 1);
+    if (pending.length) {
+      _pendingChoices[playerid] = pending;
+    } else {
+      delete _pendingChoices[playerid];
     }
 
     var ps = StateManager.getPlayer(playerid);
@@ -155,16 +192,16 @@ var BoonManager = (function () {
 
     ps.boons.push({
       cardId: cardId,
-      name: card.get('name'),
-      rarity: rarity,
-      ancestor: getAncestorFromDeck(deckName),
+      name: card.name,
+      rarity: rarityCode,
+      ancestor: card._ancestorName || card.ancestor || 'Unknown',
       acquiredAt: new Date().toISOString(),
       cost: cost
     });
 
     var playerName = getPlayerName(playerid);
-    var rarityLabel = rarity === 'S' ? 'Signature' : (rarity === 'G' ? 'Greater' : 'Common');
-    var message = '🌟 You gained <b>' + card.get('name') + '</b> (' + rarityLabel + ') for ' + cost + ' Scrip!';
+    var rarityLabel = rarityCode === 'S' ? 'Signature' : (rarityCode === 'G' ? 'Greater' : 'Common');
+    var message = '🌟 You gained <b>' + card.name + '</b> (' + rarityLabel + ') for ' + cost + ' Scrip!';
 
     if (typeof UIManager !== 'undefined' && typeof UIManager.whisper === 'function') {
       UIManager.whisper(playerName, 'Boon Purchased', message);

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -244,6 +244,22 @@ var RunFlowManager = (function () {
     run.ancestor = valid;
     run.lastPrompt = null;
 
+    if (typeof StateManager !== 'undefined' && typeof StateManager.getPlayer === 'function') {
+      var gmPlayer = StateManager.getPlayer(playerid) || {};
+      gmPlayer.ancestor_id = valid;
+      if (typeof StateManager.setPlayer === 'function') {
+        StateManager.setPlayer(playerid, gmPlayer);
+      } else {
+        if (!state.HoardRun) {
+          state.HoardRun = {};
+        }
+        if (!state.HoardRun.players) {
+          state.HoardRun.players = {};
+        }
+        state.HoardRun.players[playerid] = gmPlayer;
+      }
+    }
+
     var info = ANCESTOR_INFO[valid];
     var head = info ? '<b>' + _.escape(info.title) + '</b>' : '<b>' + _.escape(valid) + '</b>';
     var blurb = info ? '<div style="margin-top:4px;color:#bbb">' + _.escape(info.desc) + '</div>' : '';
@@ -329,10 +345,9 @@ var RunFlowManager = (function () {
         );
 
         if (typeof BoonManager !== 'undefined' && run.ancestor && run.currentRoom > 1) {
-          var safe = run.ancestor.replace(/\s+/g, '_');
           sendDirect('Boon Opportunity',
             '✨ ' + _.escape(run.ancestor) + ' offers a new boon choice.<br>' +
-            '[Draw Boons](!offerboons ' + safe + ')'
+            '[Draw Boons](!offerboons)'
           );
         }
       }

--- a/src/modules/stateManager.js
+++ b/src/modules/stateManager.js
@@ -55,6 +55,16 @@ var StateManager = (function () {
     return state.HoardRun.players[playerid];
   }
 
+  /** Persists a player's data back into state */
+  function setPlayer(playerid, payload) {
+    init();
+    if (!state.HoardRun.players) {
+      state.HoardRun.players = {};
+    }
+    state.HoardRun.players[playerid] = payload;
+    return state.HoardRun.players[playerid];
+  }
+
   /** Adds currency (Scrip, FSE, Squares, etc.) */
   function addCurrency(playerid, type, amount) {
     const p = getPlayer(playerid);
@@ -94,6 +104,7 @@ var StateManager = (function () {
     init,
     initPlayer,
     getPlayer,
+    setPlayer,
     addCurrency,
     spendScrip,
     resetAll,


### PR DESCRIPTION
## Summary
- update BoonManager to pull ancestor boons directly from BoonDataLoader decks using canonical keys and local pending choice tracking
- ensure boon selection uses stored rarity metadata for pricing and logging
- persist the selected ancestor on the player state and simplify the Draw Boons prompt

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e22cce8b4c832e8175ebc92b4b9621