### PR TITLE
feat: inline boon offers with free mode support

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,8 +11,8 @@
 - `!openshop` — Summon Bing, Bang & Bongo's shop interface for purchases.
 
 ## Boons
-- `!offerboons <Ancestor>` — Present boon choices tied to the specified Ancestor.
-- `!chooseboon <CardID>` — Claim a boon from the current offering.
+- `!offerboons <Ancestor> [free|shop]` — Present boon choices tied to the specified Ancestor. Use `free` (default) for post-room rewards or `shop` to charge Scrip by rarity.
+- `!chooseboon <ChoiceIndex>` — Claim a boon from the current offering by its displayed index.
 
 ## Currency Utilities
 - `!tradeSquares scrip|fse` — Convert Squares into the specified currency reward.

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -345,9 +345,10 @@ var RunFlowManager = (function () {
         );
 
         if (typeof BoonManager !== 'undefined' && run.ancestor && run.currentRoom > 1) {
+          var safe = run.ancestor.replace(/\s+/g, '_');
           sendDirect('Boon Opportunity',
             '✨ ' + _.escape(run.ancestor) + ' offers a new boon choice.<br>' +
-            '[Draw Boons](!offerboons)'
+            '[Draw Boons](!offerboons ' + safe + ' free)'
           );
         }
       }


### PR DESCRIPTION
## Summary
- render boon offers inline with rarity labels, rules text, and per-player tracking
- allow boon offers to distinguish between free rewards and shop purchases when spending scrip
- update run flow and documentation so end-of-room prompts draw free boon offers by default

## Testing
- not run (roll20 sandbox only)


------
https://chatgpt.com/codex/tasks/task_e_68e22fc454a0832e9ade614d13d350df