### PR TITLE
feat: add vladren bind workflow

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,3 +24,4 @@
 - `!testrelic` — Roll a random relic using DeckManager (falls back to static data if decks are missing).
 - `!givevladren` — Installs the Vladren Moroi kit on the issuing GM for testing the ancestor token actions.
 - `!resetvladren` — Resets short-rest charges for Vladren Moroi features on the issuing GM.
+- `!bindvladren` — Mirrors Vladren Moroi's token action buttons onto the currently selected PC (GM only).

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -242,19 +242,28 @@ var RunFlowManager = (function () {
     }
 
     run.ancestor = valid;
-    run.lastPrompt = null;
 
     try {
       if (typeof AncestorKits !== 'undefined' && AncestorKits.Vladren && valid === 'Vladren Moroi') {
+        // Create the kit + handout as before (stats optional)
         AncestorKits.Vladren.install(playerid, {
-          // optionally pre-fill stats so the buttons don’t ask:
           // pb: 3,
           // spellMod: 4
         });
+        // ✅ Whisper the slick “bind to selected PC” button to the GM
+        if (typeof AncestorKits.Vladren.promptBindToSelectedPC === 'function') {
+          AncestorKits.Vladren.promptBindToSelectedPC();
+        } else {
+          if (typeof promptBindToSelectedPC === 'function') {
+            promptBindToSelectedPC();
+          }
+        }
       }
     } catch (e) {
-      log('[RunFlow] Vladren install error: ' + e.message);
+      log('[RunFlow] Vladren bind prompt error: ' + e.message);
     }
+
+    run.lastPrompt = null;
 
     if (typeof StateManager !== 'undefined' && typeof StateManager.getPlayer === 'function') {
       var gmPlayer = StateManager.getPlayer(playerid) || {};


### PR DESCRIPTION
## Summary
- ensure Vladren kit characters appear in the owning player's journal and expose the GM binding helper
- add a !bindvladren command to mirror Vladren token actions to the selected PC and whisper the binding prompt to the GM
- trigger the binding prompt automatically after selecting Vladren and document the new GM utility command

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e2dcbcc61c832e8ca924d8ddf0a9f3