### PR TITLE
refactor: unify relic deck data source

### DIFF
--- a/src/modules/deckManager.js
+++ b/src/modules/deckManager.js
@@ -16,153 +16,60 @@ var DeckManager = (function () {
   // ------------------------------------------------------------
   // Static deck data (for manual import + fallback draws)
   // ------------------------------------------------------------
-  // This mirrors the JSON file in /src/data/Relics.json so the
-  // API script can still simulate draws even if the Roll20 deck
-  // has not been created yet. When Roll20 grants create/update
-  // permissions for card decks we can use this payload to seed
-  // everything automatically.
-  var STATIC_DECK_DATA = {
-    Relics: {
-      Common: [
-        {
-          id: "relic_quickcast_signet_C",
-          name: "Quickcast Signet",
-          rarity: "Common",
-          category: "Tempo",
-          price: 30,
-          text_in_run: "Once per room, you may cast a cantrip as a bonus action.",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Tempo", "Casting", "BonusAction"]
-        },
-        {
-          id: "relic_second_wind_flask_C",
-          name: "Second Wind Flask",
-          rarity: "Common",
-          category: "Defense",
-          price: 25,
-          text_in_run: "Once per room, heal 2d8 HP as a bonus action.",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Defense", "Healing", "Sustain"]
-        },
-        {
-          id: "relic_encore_coin_C",
-          name: "Encore Coin",
-          rarity: "Common",
-          category: "Reroll",
-          price: 30,
-          text_in_run: "Once per room, reroll any d20 you roll (you must use the new result).",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Reroll", "Dice", "Control"]
-        },
-        {
-          id: "relic_midas_marker_C",
-          name: "Midas Marker",
-          rarity: "Common",
-          category: "Economy",
-          price: 25,
-          text_in_run: "Gain +5 Scrip after every room.",
-          uses: { cadence: "per_room", value: 0 },
-          tags: ["Economy", "Currency"]
-        }
-      ],
-      Greater: [
-        {
-          id: "relic_quickcast_signet_G",
-          name: "Quickcast Signet (Greater)",
-          rarity: "Greater",
-          category: "Tempo",
-          price: 50,
-          text_in_run: "Twice per room, you may cast a cantrip as a bonus action. Regains 1 use after defeating an enemy.",
-          uses: { cadence: "per_room", value: 2 },
-          tags: ["Tempo", "Casting", "BonusAction"]
-        },
-        {
-          id: "relic_second_wind_flask_G",
-          name: "Second Wind Flask (Greater)",
-          rarity: "Greater",
-          category: "Defense",
-          price: 45,
-          text_in_run: "Heal 4d8 HP and cleanse 1 condition once per room.",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Defense", "Healing", "Cleanse"]
-        },
-        {
-          id: "relic_encore_coin_G",
-          name: "Encore Coin (Greater)",
-          rarity: "Greater",
-          category: "Reroll",
-          price: 50,
-          text_in_run: "Twice per room, reroll any d20 you or an ally roll.",
-          uses: { cadence: "per_room", value: 2 },
-          tags: ["Reroll", "Dice", "AllySupport"]
-        },
-        {
-          id: "relic_midas_marker_G",
-          name: "Midas Marker (Greater)",
-          rarity: "Greater",
-          category: "Economy",
-          price: 45,
-          text_in_run: "Gain +10 Scrip after every room and +1 reroll token at the first shop.",
-          uses: { cadence: "per_room", value: 0 },
-          tags: ["Economy", "Currency", "Reroll"]
-        }
-      ],
-      Signature: [
-        {
-          id: "relic_quickcast_signet_S",
-          name: "Quickcast Signet (Signature)",
-          rarity: "Signature",
-          category: "Tempo",
-          price: 70,
-          text_in_run: "Once per turn, cast any spell of 2nd level or lower as a bonus action (1/room).",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Tempo", "Casting", "BonusAction"]
-        },
-        {
-          id: "relic_second_wind_flask_S",
-          name: "Second Wind Flask (Signature)",
-          rarity: "Signature",
-          category: "Defense",
-          price: 70,
-          text_in_run: "Heal 5d8 HP, cleanse all conditions, and gain resistance to all damage until the start of your next turn (1/room).",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Defense", "Healing", "Cleanse", "Resistance"]
-        },
-        {
-          id: "relic_encore_coin_S",
-          name: "Encore Coin (Signature)",
-          rarity: "Signature",
-          category: "Reroll",
-          price: 70,
-          text_in_run: "Once per room, reroll any d20 (you choose which result to keep). If both are 20s, gain +1 FSE.",
-          uses: { cadence: "per_room", value: 1 },
-          tags: ["Reroll", "Luck", "ResourceGain"]
-        },
-        {
-          id: "relic_midas_marker_S",
-          name: "Midas Marker (Signature)",
-          rarity: "Signature",
-          category: "Economy",
-          price: 70,
-          text_in_run: "Gain +15 Scrip after every room. Shop rerolls cost 0 once per visit.",
-          uses: { cadence: "per_room", value: 0 },
-          tags: ["Economy", "Currency", "Discount"]
-        }
-      ]
+  // All fallback data is sourced from the canonical loaders in
+  // /src/data so Roll20 decks, static draws, and shops stay in
+  // sync. Each builder returns a fresh clone to prevent callers
+  // from mutating the underlying catalog.
+
+  function deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function bucketize(entries) {
+    var buckets = {};
+    (entries || []).forEach(function (entry) {
+      var rarity = entry.rarity || 'Common';
+      if (!buckets[rarity]) {
+        buckets[rarity] = [];
+      }
+      buckets[rarity].push(deepClone(entry));
+    });
+    return buckets;
+  }
+
+  function resolveRelicBuckets() {
+    if (typeof RelicData !== 'undefined' && RelicData.getRarityBuckets) {
+      return RelicData.getRarityBuckets();
     }
+
+    if (state && state.HoardRun && state.HoardRun.relicBuckets) {
+      return deepClone(state.HoardRun.relicBuckets);
+    }
+
+    if (state && state.HoardRun && state.HoardRun.relics) {
+      return bucketize(state.HoardRun.relics);
+    }
+
+    return null;
+  }
+
+  var STATIC_DECK_BUILDERS = {
+    Relics: resolveRelicBuckets
   };
 
   /** Helper: clone static data so consumers cannot mutate the source */
-  function cloneStaticData() {
-    return JSON.parse(JSON.stringify(STATIC_DECK_DATA));
-  }
-
-  /** Returns the local payload for a given base deck */
   function getStaticDeckData(baseName) {
-    if (!STATIC_DECK_DATA[baseName]) {
+    var builder = STATIC_DECK_BUILDERS[baseName];
+    if (!builder) {
       return null;
     }
-    return cloneStaticData()[baseName];
+
+    var data = builder();
+    if (!data) {
+      return null;
+    }
+
+    return deepClone(data);
   }
 
   /** Build a faux card object so downstream code can reuse existing paths */
@@ -199,7 +106,7 @@ var DeckManager = (function () {
 
     var baseName = parts[0];
     var rarityName = parts[1];
-    var table = STATIC_DECK_DATA[baseName];
+    var table = getStaticDeckData(baseName);
     if (!table) {
       return null;
     }


### PR DESCRIPTION
## Summary
- wrap the relic catalog in a RelicData module that returns cloned lists and rarity buckets
- load RelicData into state.HoardRun so static draws, shops, and Roll20 decks reference one dataset
- update DeckManager fallbacks to pull relic buckets from the shared loader instead of hard-coded tables

## Testing
- node - <<'NODE' (relic loader smoke check)

------
https://chatgpt.com/codex/tasks/task_e_68e2e01ab4a8832e91c1b30856a56254