### PR TITLE
Allow players to select weapons and ancestors

### DIFF
--- a/src/modules/ancestors/vladrenKit.js
+++ b/src/modules/ancestors/vladrenKit.js
@@ -231,12 +231,10 @@ var AncestorKits = (function(ns){
     if (!pcId) { sendChat('Hoard Run','/w gm ⚠️ Select the PC token first, then click again.'); return; }
 
     var ok = attachButtonsToPC(pcId);
-    if (ok) {
-      var pc = getObj('character', pcId);
-      sendChat('Hoard Run','/w gm ✅ Mirrored Vladren actions to **'+ (pc ? pc.get('name') : 'PC') +'**.');
-    } else {
-      sendChat('Hoard Run','/w gm ❌ Could not mirror actions (no character?).');
-    }
+    var pc = getObj('character', pcId);
+    sendChat('Hoard Run', '/w gm ' + (ok
+      ? ('✅ Mirrored Vladren actions to <b>' + (pc ? pc.get('name') : 'PC') + '</b>.')
+      : '❌ Could not mirror actions (no character?).'));
   });
 
   // namespace export


### PR DESCRIPTION
## Summary
- let any player fire the weapon and ancestor selection flows and persist the ancestor to their player state
- broadcast the start-run weapon chooser to all players and trigger player-specific ancestor confirmations, kit installs, and boon offers
- update the Vladren kit bind command response to provide the GM whisper requested formatting

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2df74f85c832eb360b7436aa63dda