### PR TITLE
fix: centralize first room guard in state manager

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,11 +1,11 @@
 # Hoard Run Commands
 
 ## Corridor Flow
-- `!startrun` — Begin a new Hoard Run for the issuing player. Resets currencies, inventory, and room progress.
+- `!startrun` — Begin a new Hoard Run for the issuing player. Resets currencies, inventory, and room progress via `StateManager`.
 - `!selectweapon <Weapon>` — Lock in the party's starting focus (Staff, Orb, Greataxe, Rapier, Bow).
 - `!selectancestor <Name>` — Bind the Ancestor boon package tied to the chosen weapon.
-- `!nextroom` — Advance the scripted Hoard Run flow (ancestor prompts, free boon phase, room counter).
-- `!nextr room|miniboss|boss` — Advance to the next room type in the legacy corridor system and award rewards.
+- `!nextroom` — Advance the scripted Hoard Run flow (ancestor prompts, free boon phase, room counter). Delegates currency and corridor tracking to `StateManager` so totals stay in sync with manual advances.
+- `!nextr room|miniboss|boss` — Advance to the next room type using `RoomManager`. Shares the same `StateManager` helpers as `!nextroom`, so rewards and progress only trigger once per command.
 
 ## Shops & Economy
 - `!openshop` — Summon Bing, Bang & Bongo's shop interface for purchases.

--- a/src/modules/stateManager.js
+++ b/src/modules/stateManager.js
@@ -15,7 +15,7 @@
 
 var StateManager = (function () {
 
-  const DEFAULT_PLAYER_STATE = {
+  var DEFAULT_PLAYER_STATE = {
     ancestor_id: null,
     scrip: 0,
     fse: 0,
@@ -24,16 +24,18 @@ var StateManager = (function () {
     boons: [],
     relics: [],
     upgrades: [],
-    focus: "Staff",
-    currentRoom: 1,
-    corridorLength: 6
+    focus: 'Staff',
+    currentRoom: 0,
+    corridorLength: 6,
+    hasEnteredFirstRoom: false,
+    firstClearAwarded: false
   };
 
   /** Initializes the global storage if it doesn't exist */
   function init() {
     if (!state.HoardRun) {
       state.HoardRun = { players: {}, shop: {} };
-      log("HoardRun state initialized.");
+      log('HoardRun state initialized.');
     } else if (!state.HoardRun.shop) {
       state.HoardRun.shop = {};
     }
@@ -44,7 +46,7 @@ var StateManager = (function () {
     init();
     if (!state.HoardRun.players[playerid]) {
       state.HoardRun.players[playerid] = JSON.parse(JSON.stringify(DEFAULT_PLAYER_STATE));
-      log(`Created new run data for player ${playerid}`);
+      log('Created new run data for player ' + playerid);
     }
     return state.HoardRun.players[playerid];
   }
@@ -76,27 +78,138 @@ var StateManager = (function () {
 
   /** Adds currency (Scrip, FSE, Squares, etc.) */
   function addCurrency(playerid, type, amount) {
-    const p = getPlayer(playerid);
+    var p = getPlayer(playerid);
     if (p[type] !== undefined) {
-      const current = normalizeNumber(p[type]);
-      const delta = normalizeNumber(amount);
+      var current = normalizeNumber(p[type]);
+      var delta = normalizeNumber(amount);
       p[type] = current + delta;
-      log(`${type} +${delta} for player ${playerid}`);
+      log(type + ' +' + delta + ' for player ' + playerid);
     }
+  }
+
+  /** Resets a player's corridor progress and currencies */
+  function resetPlayerRun(playerid) {
+    var p = initPlayer(playerid);
+    p.ancestor_id = null;
+    p.focus = DEFAULT_PLAYER_STATE.focus;
+    p.currentRoom = 0;
+    p.scrip = 0;
+    p.fse = 0;
+    p.squares = 0;
+    p.rerollTokens = 0;
+    p.boons = [];
+    p.relics = [];
+    p.upgrades = [];
+    p.hasEnteredFirstRoom = false;
+    p.firstClearAwarded = false;
+    return p;
+  }
+
+  /** Sets the current cleared room number */
+  function setCurrentRoom(playerid, value) {
+    var p = getPlayer(playerid);
+    var room = normalizeNumber(value);
+    p.currentRoom = room < 0 ? 0 : room;
+    return p.currentRoom;
+  }
+
+  /** Increments the current room counter and returns the new value */
+  function incrementRoom(playerid) {
+    var p = getPlayer(playerid);
+    var current = normalizeNumber(p.currentRoom);
+    p.currentRoom = current + 1;
+    return p.currentRoom;
+  }
+
+  /** Returns the player's corridor metadata */
+  function getCorridor(playerid) {
+    var p = getPlayer(playerid);
+    return {
+      currentRoom: normalizeNumber(p.currentRoom),
+      corridorLength: normalizeNumber(p.corridorLength)
+    };
+  }
+
+  /** Applies a bundle of currencies in one call */
+  function applyCurrencyBundle(playerid, bundle) {
+    if (!bundle) {
+      return getCurrencies(playerid);
+    }
+
+    if (bundle.scrip) {
+      addCurrency(playerid, 'scrip', bundle.scrip);
+    }
+    if (bundle.fse) {
+      addCurrency(playerid, 'fse', bundle.fse);
+    }
+    if (bundle.squares) {
+      addCurrency(playerid, 'squares', bundle.squares);
+    }
+    if (bundle.rerollTokens) {
+      addCurrency(playerid, 'rerollTokens', bundle.rerollTokens);
+    }
+
+    return getCurrencies(playerid);
+  }
+
+  /**
+   * Advances the corridor counter while handling the "first room" guard.
+   * Returns metadata describing whether rewards should be applied.
+   *
+   * @param {string} playerid - Roll20 player ID
+   * @param {Object} bundle - Currency rewards to apply once a room is cleared
+   * @returns {{firstEntry: boolean, clearedRoom: number, totals: Object, player: Object}}
+   */
+  function advanceRoom(playerid, bundle) {
+    var p = initPlayer(playerid);
+
+    if (!p.hasEnteredFirstRoom) {
+      p.hasEnteredFirstRoom = true;
+      return {
+        firstEntry: true,
+        clearedRoom: 0,
+        totals: getCurrencies(playerid),
+        player: p
+      };
+    }
+
+    var current = normalizeNumber(p.currentRoom);
+    current += 1;
+    p.currentRoom = current;
+
+    var totals = bundle ? applyCurrencyBundle(playerid, bundle) : getCurrencies(playerid);
+
+    return {
+      firstEntry: false,
+      clearedRoom: p.currentRoom,
+      totals: totals,
+      player: p
+    };
+  }
+
+  /** Returns the player's current currency totals */
+  function getCurrencies(playerid) {
+    var p = getPlayer(playerid);
+    return {
+      scrip: normalizeNumber(p.scrip),
+      fse: normalizeNumber(p.fse),
+      squares: normalizeNumber(p.squares),
+      rerollTokens: normalizeNumber(p.rerollTokens)
+    };
   }
 
   /** Deducts Scrip for shop purchases */
   function spendScrip(playerid, amount) {
-    const p = getPlayer(playerid);
-    const current = normalizeNumber(p.scrip);
-    const cost = normalizeNumber(amount);
+    var p = getPlayer(playerid);
+    var current = normalizeNumber(p.scrip);
+    var cost = normalizeNumber(amount);
     if (current >= cost) {
       p.scrip = current - cost;
       return true;
     } else {
-      const player = getObj('player', playerid);
-      const name = player ? player.get('_displayname') : 'Player';
-      sendChat("Hoard Run", `/w "${name}" Not enough Scrip!`);
+      var player = getObj('player', playerid);
+      var name = player ? player.get('_displayname') : 'Player';
+      sendChat('Hoard Run', '/w "' + name + '" Not enough Scrip!');
       return false;
     }
   }
@@ -104,26 +217,33 @@ var StateManager = (function () {
   /** Clears all data (use with care!) */
   function resetAll() {
     state.HoardRun = { players: {}, shop: {} };
-    log("All HoardRun data cleared.");
+    log('All HoardRun data cleared.');
   }
 
   /** Dumps a readable summary for GM */
   function debugPrint(playerid) {
-    const p = getPlayer(playerid);
-    let summary = `Scrip: ${p.scrip}, FSE: ${p.fse}, Squares: ${p.squares}, RerollTokens: ${p.rerollTokens}`;
-    sendChat("Hoard Run", `/w gm ${summary}`);
+    var p = getPlayer(playerid);
+    var summary = 'Scrip: ' + p.scrip + ', FSE: ' + p.fse + ', Squares: ' + p.squares + ', RerollTokens: ' + p.rerollTokens;
+    sendChat('Hoard Run', '/w gm ' + summary);
   }
 
   // Public API
   return {
-    init,
-    initPlayer,
-    getPlayer,
-    setPlayer,
-    addCurrency,
-    spendScrip,
-    resetAll,
-    debugPrint
+    init: init,
+    initPlayer: initPlayer,
+    getPlayer: getPlayer,
+    setPlayer: setPlayer,
+    addCurrency: addCurrency,
+    resetPlayerRun: resetPlayerRun,
+    setCurrentRoom: setCurrentRoom,
+    incrementRoom: incrementRoom,
+    getCorridor: getCorridor,
+    applyCurrencyBundle: applyCurrencyBundle,
+    advanceRoom: advanceRoom,
+    getCurrencies: getCurrencies,
+    spendScrip: spendScrip,
+    resetAll: resetAll,
+    debugPrint: debugPrint
   };
 
 })();


### PR DESCRIPTION
## Summary
- add a shared `StateManager.advanceRoom` helper that tracks first-room entry and applies corridor currency bundles once
- update `RunFlowManager` to use the shared helper so the first `!nextroom` only opens Room 1 before rewards are granted
- refactor `RoomManager.advanceRoom` to rely on the same state helper while keeping square drops and shop/boon hooks intact

## Testing
- not run (Roll20 chat environment required)


------
https://chatgpt.com/codex/tasks/task_e_68e2e017ee54832e8831a74fadf48aa8