### PR TITLE
fix: align Morvox boon deck key with ancestor canon

### DIFF
--- a/src/modules/boonDataLoader.js
+++ b/src/modules/boonDataLoader.js
@@ -273,7 +273,8 @@ var BoonDataLoader = (function () {
     },
 
     // 🌑 MORVOX — Tiny Tyrant of the Umbral Staff
-    Morvox: {
+    // Key matches canonAncestor('Morvox, Tiny Tyrant') so BoonManager can find the deck.
+    MorvoxTinyTyrant: {
       Common: [
         {
           id: 'morvox_malevolent_study',


### PR DESCRIPTION
## Summary
- align the Morvox boon deck key with the sanitized ancestor name so selection resolves
- document the canonical key usage to avoid future mismatches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f0a80f68832ea01ae63e405b8a5d