### PR TITLE
fix: preserve command arguments in run flow manager

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -503,9 +503,13 @@ var RunFlowManager = (function () {
       return;
     }
 
-    var spaceIdx = content.indexOf(' ');
-    var command = spaceIdx === -1 ? content : content.slice(0, spaceIdx);
-    var argString = spaceIdx === -1 ? '' : content.slice(spaceIdx + 1);
+    var parsed = content.match(/^(\S+)(?:\s+([\s\S]+))?$/);
+    if (!parsed) {
+      return;
+    }
+
+    var command = parsed[1];
+    var argString = parsed[2] || '';
 
     switch (command.toLowerCase()) {
       case '!startrun':


### PR DESCRIPTION
## Summary
- update command parsing in runFlowManager to tolerate non-breaking spaces and newlines
- ensure command arguments are passed intact to selection handlers

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2faa330a4832ead5b6c5ba60944c8