### PR TITLE
fix: ensure ancestor selection commands include name

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -400,8 +400,12 @@ var RunFlowManager = (function () {
           if (ancestors.length) {
             var ancestorButtons = ancestors.map(function (a) {
               var label = _.escape(a);
-              var commandName = a.replace(/"/g, '\"');
-              return { label: 'Select ' + label, command: '!selectancestor "' + commandName + '"' };
+              // Roll20 strips quoted button arguments, so encode spaces as underscores
+              // and strip stray quotes to keep the ancestor identifier intact.
+              var commandName = String(a || '')
+                .replace(/\s+/g, '_')
+                .replace(/"/g, '');
+              return { label: 'Select ' + label, command: '!selectancestor ' + commandName };
             });
             whisperPanel(pid, 'Choose Your Ancestor',
               '🌟 Bind to an ancestor to unlock room-end boons:<br><br>' + formatButtons(ancestorButtons)


### PR DESCRIPTION
## Summary
- encode ancestor picker buttons so the RunFlowManager receives the selected name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2fe1ca3f8832e8b7e6f930810f3ff