### PR TITLE
fix: reset advancing flag after next room errors

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -381,6 +381,14 @@ if (result && result.firstClearBonusFSE && result.firstClearBonusFSE > 0) {
   );
 }
 
+    } catch (e) {
+      log('[RunFlow] next room error: ' + e);
+    } finally {
+      _advancing = false;
+    }
+
+  }
+
 
   // ------------------------------------------------------------
   // Event Handling


### PR DESCRIPTION
## Summary
- log unexpected errors when advancing to the next room
- ensure the advancing guard is always reset via a finally block

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e30ea0abd0832e9312a6166b2f7943