### PR TITLE
fix: route room advancement through RoomManager

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -318,9 +318,6 @@ var result = null;
 if (typeof RoomManager !== 'undefined' && typeof RoomManager.advanceRoom === 'function') {
   // Preferred: central engine does room math and extras (squares, first-clear bonus)
   result = RoomManager.advanceRoom(playerid, 'room');
-} else if (typeof StateManager !== 'undefined' && typeof StateManager.advanceRoom === 'function') {
-  // Minimal fallback: just award base bundle
-  result = StateManager.advanceRoom(playerid, { scrip: 20, fse: 1 });
 } else {
   whisperGM('Room Engine Warning', '⚠️ Room progression engine not ready.');
   return;


### PR DESCRIPTION
## Summary
- remove the direct StateManager advance fallback so run flow always routes through RoomManager
- keep the GM warning reachable when the room engine is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30f9d41ec832e98b6c7d0231041b6