### PR TITLE
fix: treat sandbox invocations as gm for guard

### DIFF
--- a/src/modules/safetyGuards.js
+++ b/src/modules/safetyGuards.js
@@ -18,6 +18,11 @@ var SafetyGuards = (function () {
    */
   function installGMGuard() {
     root.isGM = function (playerid) {
+      if (!playerid || playerid === 'API') {
+        // Sandbox/system invocations lack a player ID but must stay GM-privileged.
+        return true;
+      }
+
       return typeof playerIsGM === 'function' ? playerIsGM(playerid) : true;
     };
   }


### PR DESCRIPTION
## Summary
- ensure the safety guard treats sandbox/system invocations as GM so console tests succeed
- document the sandbox playerid edge case for future maintenance

## Testing
- not run (Roll20 sandbox not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e325b1e980832ea21d2606d70c0265