### PR TITLE
fix: keep panel formatting on single line

### DIFF
--- a/src/modules/roomManager.js
+++ b/src/modules/roomManager.js
@@ -43,7 +43,7 @@ var RoomManager = (function () {
     if (typeof UIManager !== 'undefined' && UIManager.panel) {
       return UIManager.panel(title, body);
     }
-    return '**' + title + '**\n' + body;
+    return '<div><strong>' + title + '</strong><br>' + body + '</div>';
   }
 
   function whisperPanel(playerid, title, body) {

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -102,7 +102,7 @@ var RunFlowManager = (function () {
     if (typeof UIManager !== 'undefined' && typeof UIManager.panel === 'function') {
       return UIManager.panel(title, bodyHTML);
     }
-    return '**' + title + '**\n' + bodyHTML;
+    return '<div><strong>' + title + '</strong><br>' + bodyHTML + '</div>';
   }
 
   function formatButtons(buttons) {

--- a/src/modules/uiManager.js
+++ b/src/modules/uiManager.js
@@ -28,7 +28,7 @@ var UIManager = (function () {
    * @returns {string} HTML block
    */
   function panel(title, bodyHTML) {
-    return '**' + title + '**\n' + bodyHTML;
+    return '<div><strong>' + title + '</strong><br>' + bodyHTML + '</div>';
   }
 
   /**


### PR DESCRIPTION
## Summary
- update UIManager panel rendering to wrap title/body in a single div with a line break
- mirror the same single-line fallback in RunFlowManager and RoomManager to avoid multi-payload whispers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e32a025fe8832e851f4d5b917a344f