### PR TITLE
feat: surface scrip balance in shop

### DIFF
--- a/src/modules/shopManager.js
+++ b/src/modules/shopManager.js
@@ -299,10 +299,13 @@ var ShopManager = (function () {
     const name = getPlayerDisplayName(playerid);
 
     const shop = getPlayerShop(playerid);
+    const currencies = StateManager.getCurrencies(playerid) || {};
+    const scripTotal = typeof currencies.scrip !== "undefined" ? currencies.scrip : 0;
     const entries = slots || (shop.slots.length ? shop.slots : generateShop(playerid));
 
     let html = `<div style="border:1px solid #555;background:#111;padding:5px;color:#eee">`;
     html += `<b>Unified Shop – Bing, Bang & Bongo</b><br><br>`;
+    html += `<span style="color:#ffd700">Current Scrip: ${scripTotal}</span><br><br>`;
 
     entries.forEach((s, index) => {
       if (s.sold) return;


### PR DESCRIPTION
## Summary
- read the player's current Scrip total when rendering shop offers
- display the balance at the top of the Bing, Bang & Bongo whisper panel

## Testing
- not run (Roll20 commands require the live sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e332584b50832ebd3126fd222260ae