### PR TITLE
feat: add gm advance button for room flow

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -4,8 +4,8 @@
 - `!startrun` — Begin a new Hoard Run for the issuing player. Resets currencies, inventory, and room progress via `StateManager`.
 - `!selectweapon <Weapon>` — Lock in the party's starting focus (Staff, Orb, Greataxe, Rapier, Bow).
 - `!selectancestor <Name>` — Bind the Ancestor boon package tied to the chosen weapon.
-- `!nextroom` — (GM only) Advance the scripted Hoard Run flow (ancestor prompts, free boon phase, room counter). Delegates currency and corridor tracking to `StateManager` so totals stay in sync with manual advances.
-- `!nextr room|miniboss|boss` — Advance to the next room type using `RoomManager`. Shares the same `StateManager` helpers as `!nextroom`, so rewards and progress only trigger once per command.
+- **Advance Room button (GM whisper)** — Progress the scripted Hoard Run flow (ancestor prompts, free boon phase, room counter). The button fires the legacy `!nextroom` command so totals stay in sync with manual advances without typing.
+- `!nextr room|miniboss|boss` — Advance to the next room type using `RoomManager`. Shares the same `StateManager` helpers as the Advance Room button, so rewards and progress only trigger once per command.
 
 ## Shops & Economy
 - `!openshop` — (GM only) Summon Bing, Bang & Bongo's shop interface for each active player.

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,7 @@ on('ready', function () {
     '• <b>!startrun</b> – Begin a new Hoard Run<br>' +
     '• <b>!selectweapon [Weapon]</b> – Lock in starting focus<br>' +
     '• <b>!selectancestor [Name]</b> – Bind an Ancestor blessing<br>' +
-    '• <b>!nextroom</b> – Progress core Hoard Run flow<br>' +
+    '• [Advance Room](!nextroom) – Progress core Hoard Run flow<br>' +
     '• <b>!nextr room|miniboss|boss</b> – Legacy room advancement<br>' +
     '• <b>!openshop</b> – Open Bing, Bang & Bongo Shop<br>' +
     '• <b>!offerboons [Ancestor]</b> – Offer boon choices<br>' +

--- a/src/modules/boonManager.js
+++ b/src/modules/boonManager.js
@@ -424,8 +424,11 @@ var BoonManager = (function () {
     ensureBoonHandout(playerid, picked, offer.ancestor);
 
     var playerName = getPlayerName(playerid);
-    var message = '🌟 You gained <b>' + _.escape(picked.name) + '</b> (' + rarityLabel(rarity) + ')'
-                + (cost > 0 ? (' for ' + cost + ' Scrip!') : ' for 0 Scrip (free reward).');
+    var message = '🌟 You gained <b>' + _.escape(picked.name) + '</b> (' + rarityLabel(rarity) + ')';
+    if (cost > 0) {
+      message += ' for ' + cost + ' Scrip';
+    }
+    message += '!';
 
     if (UIManager && UIManager.whisper) {
       UIManager.whisper(playerName, 'Boon Gained', message);

--- a/src/modules/roomManager.js
+++ b/src/modules/roomManager.js
@@ -243,9 +243,9 @@ var RoomManager = (function () {
       var title = type === 'boss' ? 'Boss Room Ready' : 'Room ' + nextRoom + ' Ready';
       var body;
       if (type === 'boss') {
-        body = '👑 The final chamber awaits.<br>Run the encounter, then the GM will use <b>!nextroom</b> to deliver rewards.';
+        body = '👑 The final chamber awaits.<br>Run the encounter, then the GM will advance once combat ends.';
       } else {
-        body = '⚔️ Room ' + nextRoom + ' Ready.<br>Resolve the encounter, then the GM will advance with <b>!nextroom</b>.';
+        body = '⚔️ Room ' + nextRoom + ' Ready.<br>Resolve the encounter, then the GM will advance once you are victorious.';
       }
       whisperPanel(playerid, title, body);
       announceShop(playerid, 'enter', nextRoom);
@@ -309,7 +309,7 @@ var RoomManager = (function () {
       if (StateManager.setPlayer) {
         StateManager.setPlayer(playerid, playerState);
       }
-      whisperPanel(playerid, 'Room ' + nextRoom + ' Ready', '⚔️ Proceed into the chamber and the GM will use <b>!nextroom</b> after the fight.');
+      whisperPanel(playerid, 'Room ' + nextRoom + ' Ready', '⚔️ Proceed into the chamber and the GM will advance after the fight.');
       announceShop(playerid, 'enter', nextRoom);
       return {
         status: 'ready',

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -73,6 +73,21 @@ var RunFlowManager = (function () {
     }).join('<br>');
   }
 
+  function renderAdvanceRoomButton() {
+    return formatButtons([
+      { label: 'Advance Room ▶️', command: '!nextroom' }
+    ]);
+  }
+
+  function whisperAdvanceRoomPrompt(message, title) {
+    var segments = [];
+    if (message) {
+      segments.push(message);
+    }
+    segments.push(renderAdvanceRoomButton());
+    whisperGM(title || 'Advance Room', segments.join('<br><br>'));
+  }
+
   function whisperGM(title, bodyHTML) {
     if (typeof HRChat !== 'undefined' && HRChat && typeof HRChat.say === 'function') {
       HRChat.say('/w gm ' + formatPanel(title, bodyHTML));
@@ -354,6 +369,7 @@ var RunFlowManager = (function () {
     }
 
     log('[RunFlow] New Hoard Run started — awaiting weapon selections.');
+    whisperAdvanceRoomPrompt('Click after each encounter to distribute room rewards.', 'Advance Room Control');
   }
 
   function handleSelectWeapon(playerid, arg) {
@@ -389,7 +405,7 @@ var RunFlowManager = (function () {
       'Weapon Chosen',
       '🗡️ Weapon locked: <b>' + weapon + '</b>.<br>' +
       'Your run progress will now be tracked under your player ID.<br><br>' +
-      'The GM will advance rooms with <b>!nextroom</b> once each encounter is finished.'
+      'The GM will advance rooms once each encounter is finished.'
     );
     log('[RunFlow] Weapon selected for ' + playerid + ': ' + weapon);
   }
@@ -535,7 +551,10 @@ var RunFlowManager = (function () {
 
     var run = getRun();
     run.bossPending = true;
-    whisperGM('Final Room Flagged', '👑 Next <b>!nextroom</b> call will prepare the boss encounter for each player.');
+    whisperAdvanceRoomPrompt(
+      '👑 Final chamber flagged. Use the button below after the boss encounter to deliver rewards for each player.',
+      'Final Room Flagged'
+    );
   }
 
   function handleCompleteRun(playerid) {


### PR DESCRIPTION
## Summary
- whisper a reusable Advance Room button to the GM and update player whispers to remove the !nextroom text
- refresh room progression docs and GM init message to point to the button-driven flow
- drop the redundant "for 0 Scrip (free reward)" suffix on free boon claims for cleaner chat output

## Testing
- not run (Roll20 sandbox environment)


------
https://chatgpt.com/codex/tasks/task_e_68e34c41a2a4832e90c193b079bfd479