### PR TITLE
fix: repeat advance room prompt

### DIFF
--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -471,8 +471,10 @@ var RunFlowManager = (function () {
     if (_advancing) return;
     _advancing = true;
 
+    var run;
+
     try {
-      var run = getRun();
+      run = getRun();
       if (!run.started) {
         whisperText(playerid, '⚠️ No active run. Use <b>!startrun</b> first.');
         return;
@@ -539,6 +541,14 @@ var RunFlowManager = (function () {
       log('[RunFlow] next room error: ' + e);
     } finally {
       _advancing = false;
+
+      if (run && run.started) {
+        var promptMessage = run.bossPending
+          ? '👑 Boss room still active. Click after the encounter to distribute boss rewards again.'
+          : 'Click after each encounter to distribute room rewards.';
+        var promptTitle = run.bossPending ? 'Advance Boss Room' : 'Advance Room Control';
+        whisperAdvanceRoomPrompt(promptMessage, promptTitle);
+      }
     }
 
   }


### PR DESCRIPTION
## Summary
- re-whisper the Advance Room control after each `!nextroom` processing
- show tailored reminder text when a boss room is pending vs. standard rooms

## Testing
- not run (Roll20 sandbox-only)

------
https://chatgpt.com/codex/tasks/task_e_68e34eb0b780832ea206d55d6b789cf1