### PR TITLE
fix: prompt gm to bind ancestor kits

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -26,4 +26,4 @@
 - `!givevladren` — Installs the Vladren Moroi kit on the issuing GM for testing the ancestor token actions.
 - `!resetvladren` — Resets short-rest charges for Vladren Moroi features on the issuing GM.
 - `!bindvladren` — Mirrors Vladren Moroi's token action buttons onto the currently selected PC (GM only).
-- `!bindkit <Ancestor>` — (GM only) Mirrors the registered Ancestor kit abilities onto the selected PC token using `AncestorKits`.
+- `!bindkit <Ancestor>` — (GM only) Mirrors the registered Ancestor kit abilities onto the selected PC token using `AncestorKits`. The mirrored macros live on the sheet's **Attributes & Abilities** tab and show up as token action buttons for that character.


### PR DESCRIPTION
## Summary
- detect when a selected ancestor has a registered kit and whisper binding instructions to the GM
- explain how to mirror the kit and where the mirrored actions appear on the character sheet
- document that !bindkit adds abilities to the sheet's Attributes & Abilities tab and token actions

## Testing
- not run (Roll20 sandbox environment)


------
https://chatgpt.com/codex/tasks/task_e_68e34f87c714832e8937f58c428faa29