### PR TITLE
fix: align shop draws with updated rarity dials

### DIFF
--- a/docs/hoard-card-system.md
+++ b/docs/hoard-card-system.md
@@ -16,8 +16,8 @@ Default payout dials: successful run grants 20 FSE; expect ~20 Scrip per room pl
 ## Shop Loop Overview
 
 1. **Enter Shop** after Room 3 (mandatory) and optionally after Room 5.
-2. **Deal Relics**: Generate three Relic slots. For each slot roll rarity (suggested 55% Common / 35% Greater / 10% Signature) and draw from the matching deck.
-3. **Offer Boon**: Draw a single ancestor-specific Boon (rarity by table dial; default 45/40/15 for C/G/S) and present it alongside the relics.
+2. **Deal Relics**: Generate three Relic slots. For each slot roll rarity using the 45% Common / 40% Greater / 15% Signature dial and draw from the matching deck.
+3. **Offer Boon**: Draw a single ancestor-specific Boon using the same 45/40/15 rarity dial (C/G/S) and present it alongside the relics.
 4. **Purchasing**: Players spend Scrip at the default prices listed per deck below.
 5. **Rerolls**:
    * Single-slot reroll costs 15 Scrip, max twice per visit.


### PR DESCRIPTION
## Summary
- update the shop rarity weights so relic slots roll against the 45/40/15 dial and keep signature relics in circulation for every visit
- ensure the boon slot always sources an ancestor-specific card using the same rarity table while retaining the 65 Scrip price point
- refresh the card system documentation to reflect the new relic and boon rarity expectations

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e350411e68832ea98238fd5dc7fbb3