### PR TITLE
Fix ancestor kit alias lookups

### DIFF
--- a/src/modules/ancestorKits.core.js
+++ b/src/modules/ancestorKits.core.js
@@ -410,6 +410,16 @@ var AncestorKits = (function (ns) {
     _defs[key] = stored;
     _aliasIndex[key] = key;
 
+    var ancestorKey = canonName(ancestorName);
+    if (ancestorKey) {
+      _aliasIndex[ancestorKey] = key;
+    }
+
+    var buttonKey = canonName(stored.buttonLabel);
+    if (buttonKey) {
+      _aliasIndex[buttonKey] = key;
+    }
+
     if (def.aliases && def.aliases.length) {
       def.aliases.forEach(function (alias) {
         var aliasKey = canonName(alias);

--- a/src/modules/runFlowManager.js
+++ b/src/modules/runFlowManager.js
@@ -135,7 +135,9 @@ var RunFlowManager = (function () {
     if (!key) {
       return false;
     }
-    return !!AncestorKits._defs[key];
+    var aliasIndex = AncestorKits._aliasIndex || {};
+    var resolved = aliasIndex[key] || key;
+    return !!AncestorKits._defs[resolved];
   }
 
   function promptAncestorKitBinding(ancestorName) {


### PR DESCRIPTION
## Summary
- resolve ancestor kit lookups against the alias index before falling back to raw keys
- populate the alias index with canonical ancestor and button labels when registering kits

## Testing
- not run (Roll20 sandbox not available)


------
https://chatgpt.com/codex/tasks/task_e_68e35bf96ef4832e9201acda44c2f339