### PR TITLE
feat: clear mirrored abilities during reset

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -18,7 +18,7 @@
 - `!tradeSquares scrip|fse` — Convert Squares into the specified currency reward.
 
 ## Developer Utilities (GM Only)
-- `!resetstate` — Wipe all Hoard Run data from the persistent state object.
+- `!resetstate` — Wipe all Hoard Run data and purge mirrored kit abilities from player sheets.
 - `!debugstate [playerName|playerId]` — Whisper the current Hoard Run state block (optionally filtered to a player).
 - `!testshop` — Generate a mock Bing, Bang & Bongo shop for the first online player.
 - `!testrelic` — Roll a random relic using DeckManager (falls back to static data if decks are missing).

--- a/src/modules/devTools.js
+++ b/src/modules/devTools.js
@@ -25,6 +25,9 @@ var DevTools = (function () {
    * Clears all progress, currencies, boons, etc.
    */
   function resetState() {
+    if (typeof AncestorKits !== 'undefined' && AncestorKits && typeof AncestorKits.clearAllMirroredAbilities === 'function') {
+      AncestorKits.clearAllMirroredAbilities();
+    }
     delete state.HoardRun;
     state.HoardRun = { players: {}, version: 'dev' };
     if (typeof RunFlowManager !== 'undefined' && typeof RunFlowManager.resetRunState === 'function') {


### PR DESCRIPTION
## Summary
- add an AncestorKits helper to remove mirrored abilities from all registered kit prefixes
- hook the new helper into !resetstate and document that the command now purges mirrored actions

## Testing
- not run (Roll20 API sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e485742c8c832ea07c76a337ab6f9d