### PR TITLE
feat: add gm shop buttons after room clears

### DIFF
--- a/src/modules/roomManager.js
+++ b/src/modules/roomManager.js
@@ -159,6 +159,19 @@ var RoomManager = (function () {
     if (!roomNumber) {
       return;
     }
+    if (phase === 'clear' && (roomNumber === 3 || roomNumber === 5)) {
+      var buttonHtml = '[Open Shop](!openshop)';
+      if (typeof UIManager !== 'undefined' && UIManager && typeof UIManager.buttons === 'function') {
+        buttonHtml = UIManager.buttons([{ label: 'Open Shop', command: 'openshop' }]);
+      }
+      var gmContent = 'Room ' + roomNumber + ' cleared — open Bing, Bang & Bongo when the party is ready.<br>' + buttonHtml;
+      var gmMessage = formatPanel('Shop Ready', gmContent);
+      if (typeof UIManager !== 'undefined' && UIManager && typeof UIManager.gmLog === 'function') {
+        UIManager.gmLog(gmMessage);
+      } else {
+        sendChat('Hoard Run', '/w gm ' + gmMessage);
+      }
+    }
     if (roomNumber === 3) {
       whisperText(playerid, '🛒 Shop Available — the GM can open Bing, Bang & Bongo with <b>!openshop</b>.');
     }


### PR DESCRIPTION
## Summary
- whisper a GM-only panel with an Open Shop button after rooms 3 and 5 are cleared
- reuse UIManager helpers so the panel respects existing styling

## Testing
- not run (roll20 API script environment)


------
https://chatgpt.com/codex/tasks/task_e_68e48beebdec832eaf38cb3a7c7a8140