### PR TITLE
Fix mirrored ability reset to be case-insensitive

### DIFF
--- a/src/modules/ancestorKits.core.js
+++ b/src/modules/ancestorKits.core.js
@@ -282,7 +282,7 @@ var AncestorKits = (function (ns) {
 
     var pattern = prefix instanceof RegExp
       ? prefix
-      : new RegExp('^' + escapeRegExp(prefix));
+      : new RegExp('^' + escapeRegExp(prefix), 'i');
 
     findObjs({ _type: 'ability', _characterid: characterId }).forEach(function (ability) {
       var name = ability.get('name');
@@ -640,7 +640,7 @@ var AncestorKits = (function (ns) {
     }
 
     if (!stored.stripPattern && stored.abilityPrefix) {
-      stored.stripPattern = new RegExp('^' + escapeRegExp(stored.abilityPrefix));
+      stored.stripPattern = new RegExp('^' + escapeRegExp(stored.abilityPrefix), 'i');
     }
 
     _defs[key] = stored;


### PR DESCRIPTION
## Summary
- update the ancestor kit registry to build case-insensitive strip patterns for mirrored abilities
- ensure the removal helper treats plain-text prefixes case-insensitively so reset commands catch historical ability names

## Testing
- not run (Roll20 API environment only)

------
https://chatgpt.com/codex/tasks/task_e_68e49a1eed68832e96b692f59e2565c1