### PR TITLE
feat: carry boon effect identifiers into state

### DIFF
--- a/src/modules/ancestorRegistry.js
+++ b/src/modules/ancestorRegistry.js
@@ -82,6 +82,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'azuren_stationary_battery',
+          effectId: 'azuren_stationary_battery',
           name: 'Stationary Battery',
           text_in_run:
             'If you end your turn moving ≤5 ft, regain +1 extra Charge (total +2), and your next Arcanopulse before the end of your next turn deals +PB lightning.',
@@ -89,6 +90,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'azuren_longshot_schema',
+          effectId: 'azuren_longshot_schema',
           name: 'Longshot Schema',
           text_in_run:
             'While you have ≥2 Charges, your spell attacks vs. targets >60 ft get +1 to hit, and targets >60 ft have −1 to their saves vs your spells.',
@@ -98,6 +100,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'azuren_overchannel_pulse',
+          effectId: 'azuren_overchannel_pulse',
           name: 'Overchannel Pulse',
           text_in_run:
             'Arcanopulse loses Recharge (use it freely). It costs 1 Charge to fire; you may still spend up to 3 more to empower it as normal. Its width becomes 10 ft if you spend ≥2 Charges on it.',
@@ -105,6 +108,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'azuren_eye_of_annihilation',
+          effectId: 'azuren_eye_of_annihilation',
           name: 'Eye of Annihilation',
           text_in_run:
             'Eye of Destruction radius 15 ft; the center 5-ft deals +PBd6 lightning and imposes disadvantage on Dex saves until the end of the target’s next turn.',
@@ -112,6 +116,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'azuren_conductive_mark',
+          effectId: 'azuren_conductive_mark',
           name: 'Conductive Mark',
           text_in_run:
             'When lightning bolt damages a creature, it becomes Conductive until the end of your next turn; your next Arcanopulse or Barrage against a Conductive target deals +2d8.',
@@ -121,6 +126,7 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'azuren_icon_of_ascension',
+          effectId: 'azuren_icon_of_ascension',
           name: 'Icon of Ascension',
           text_in_run:
             'Max Charges 7; start each room with 4. Rite range becomes 600 ft and you gain a 4th Barrage.',
@@ -128,6 +134,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'azuren_shocking_orb',
+          effectId: 'azuren_shocking_orb',
           name: 'Shocking Orb (1/SR)',
           text_in_run:
             'Bonus Action; 90 ft. Make a ranged spell attack: on a hit, 3d8 lightning, and the target must make a Con save or be stunned until the end of its next turn.',
@@ -135,6 +142,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'azuren_storm_conductor',
+          effectId: 'azuren_storm_conductor',
           name: 'Storm Conductor',
           text_in_run:
             'Spell empowerments: guiding bolt — on hit, restore 1 Charge and the next Arcanopulse against that target has advantage (attack) or imposes disadvantage on its Dex save (your choice). storm sphere — while the sphere persists, you regain 1 Charge at the start of each of your turns.',
@@ -161,6 +169,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'vayla_soulflare_echo',
+          effectId: 'vayla_soulflare_echo',
           name: 'Soulflare Echo',
           text_in_run:
             'Bolt leaves a 10-ft zone at the target’s space until your next turn; creatures that enter/start there take PB radiant.',
@@ -168,6 +177,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vayla_safeguard',
+          effectId: 'vayla_safeguard',
           name: 'Safeguard',
           text_in_run:
             'Ward also grants +1 AC until your next turn; if you Warded an ally, you gain temp HP = PB.',
@@ -175,6 +185,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vayla_fettering_thread',
+          effectId: 'vayla_fettering_thread',
           name: 'Fettering Thread',
           text_in_run:
             'Bond range 40 ft; when it resolves, it deals an extra +PBd6 psychic.',
@@ -184,6 +195,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'vayla_radiant_bloom',
+          effectId: 'vayla_radiant_bloom',
           name: 'Radiant Bloom',
           text_in_run:
             'Bolt adds +PBd8 to the main target and the secondary blast becomes 15-ft (Dex save) for PBd6; if the main target drops, deal max on the blast.',
@@ -191,6 +203,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vayla_twin_resolve',
+          effectId: 'vayla_twin_resolve',
           name: 'Twin Resolve',
           text_in_run:
             'Bond may tether up to two creatures affected by the spell (each checks the tether separately). When either resolves, you also heal PB + spell level.',
@@ -198,6 +211,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vayla_bastion_mantra',
+          effectId: 'vayla_bastion_mantra',
           name: 'Bastion Mantra',
           text_in_run:
             'Ward becomes a 10-ft-radius pulse around the chosen target, affecting up to PB creatures; each gains resistance to one damage type you choose until your next turn.',
@@ -207,18 +221,21 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'vayla_twin_mantra',
+          effectId: 'vayla_twin_mantra',
           name: 'Twin Mantra',
           text_in_run: 'You can Mantra 2/Short Rest.',
           hook: 'Balance'
         },
         {
           id: 'vayla_harmony_mantra',
+          effectId: 'vayla_harmony_mantra',
           name: 'Harmony Mantra',
           text_in_run: 'When you Mantra, you may apply two different Forms to that spell.',
           hook: 'Radiant'
         },
         {
           id: 'vayla_ascendant_aegis',
+          effectId: 'vayla_ascendant_aegis',
           name: 'Ascendant Aegis',
           text_in_run:
             'Ward grants its targets resistance to all damage and immunity to charmed & frightened until the start of your next turn.',
@@ -246,6 +263,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'vladren_thickened_vitae',
+          effectId: 'vladren_thickened_vitae',
           name: 'Thickened Vitae',
           text_in_run:
             'false life on yourself is 1/room without a slot and grants +PB additional temp HP. While you have temp HP, +10 ft speed.',
@@ -253,6 +271,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vladren_crimson_drip',
+          effectId: 'vladren_crimson_drip',
           name: 'Crimson Drip',
           text_in_run:
             'Transfusion deals +1d8 necrotic and, on a kill, refreshes Transfusion (you can use it again this turn).',
@@ -262,6 +281,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'vladren_tides_of_blood',
+          effectId: 'vladren_tides_of_blood',
           name: 'Tides of Blood',
           text_in_run:
             'Action (1/turn): a 15-ft radius surge centered on you; creatures Con save or take 4d6 necrotic + PB (half on success). You may lose up to PBd6 HP to add that much necrotic to the surge; you heal for half the total damage dealt.',
@@ -269,6 +289,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vladren_sovereign_pool',
+          effectId: 'vladren_sovereign_pool',
           name: 'Sovereign Pool',
           text_in_run:
             'Sanguine Pool gains +15 ft move when you enter it and recharges on 5–6 at the start of your turn while you have ≥10 temp HP.',
@@ -278,6 +299,7 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'vladren_crimson_apotheosis',
+          effectId: 'vladren_crimson_apotheosis',
           name: 'Crimson Apotheosis (1/SR)',
           text_in_run:
             'For 2 rounds, your temp HP cap doubles, you have resistance to all damage, and Transfusion can be used twice each turn (still one Bonus Action each).',
@@ -285,6 +307,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'vladren_hemarchs_decree',
+          effectId: 'vladren_hemarchs_decree',
           name: 'Hemarch’s Decree',
           text_in_run:
             'Hemoplague also makes affected creatures vulnerable to necrotic until the burst resolves; the burst deals +2d6 necrotic, and you gain advantage on attacks and +1 to spell save DC against Plagued creatures.',
@@ -311,6 +334,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'lian_flicker_step',
+          effectId: 'lian_flicker_step',
           name: 'Flicker Step',
           text_in_run:
             'When you Veilcloak or Shatter, you may teleport 10 ft to a space you can see.',
@@ -318,6 +342,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_spreading_lies',
+          effectId: 'lian_spreading_lies',
           name: 'Spreading Lies',
           text_in_run:
             'When a spell you cast damages 2+ creatures, you may Veil up to two of them (your choice) instead of only one.',
@@ -325,6 +350,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_mirrored_guard',
+          effectId: 'lian_mirrored_guard',
           name: 'Mirrored Guard',
           text_in_run:
             'mirror image: you conjure +1 extra duplicate, and the first creature that misses you each round while a duplicate remains gains 1 Veil (once per creature per round).',
@@ -334,6 +360,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'lian_pattern_weaver',
+          effectId: 'lian_pattern_weaver',
           name: 'Pattern Weaver',
           text_in_run:
             'hypnotic pattern: all creatures who can see the pattern gain 1 Veil; those who fail the save gain 2 Veils instead.',
@@ -341,6 +368,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_invisible_hand',
+          effectId: 'lian_invisible_hand',
           name: 'Invisible Hand',
           text_in_run:
             'While Veilcloak is active, you don’t provoke opportunity attacks and gain +10 ft speed; casting cantrips still doesn’t break it.',
@@ -348,6 +376,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_mirrorbreak',
+          effectId: 'lian_mirrorbreak',
           name: 'Mirrorbreak',
           text_in_run:
             'Shatter deals 2d12/stack + PB instead, and on a failed save the target is blinded and silenced until the end of its next turn (at 3 stacks, it’s stunned as well).',
@@ -357,6 +386,7 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'lian_everlasting_lies',
+          effectId: 'lian_everlasting_lies',
           name: 'Everlasting Lies',
           text_in_run:
             'Your Veils no longer expire. You can maintain persistent Veils on up to PB different creatures at a time.',
@@ -364,6 +394,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_cataclysmic_shatter',
+          effectId: 'lian_cataclysmic_shatter',
           name: 'Cataclysmic Shatter (1/SR)',
           text_in_run:
             'This turn, Shatter is a Bonus Action and deals 3d8/stack + PB. Each time Shatter drops a creature this turn, all enemies within 10 ft of it gain 1 Veil.',
@@ -371,6 +402,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'lian_static_scream',
+          effectId: 'lian_static_scream',
           name: 'Static Scream',
           text_in_run:
             'synaptic static: adds +PB psychic, and creatures that fail the save gain 2 Veils (1 Veil on a success). While they remain Veiled, they have disadvantage on the end-of-turn save to end the spell’s debuff.',
@@ -397,6 +429,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'morvox_malevolent_study',
+          effectId: 'morvox_malevolent_study',
           name: 'Malevolent Study',
           text_in_run:
             'Max Malice +3, and you start each room with 2 Malice.',
@@ -404,6 +437,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'morvox_baleful_momentum',
+          effectId: 'morvox_baleful_momentum',
           name: 'Baleful Momentum',
           text_in_run:
             'Once per turn, when a creature fails a save vs your Ancestor spell, gain +1 additional Malice.',
@@ -413,6 +447,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'morvox_collapsing_star',
+          effectId: 'morvox_collapsing_star',
           name: 'Collapsing Star',
           text_in_run:
             'Dark Star falls at the end of this turn instead of next; radius 15 ft. If Dark Star lands while a creature is in your Event Horizon ring, creatures that fail are stunned instead of prone.',
@@ -420,6 +455,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'morvox_grand_horizon',
+          effectId: 'morvox_grand_horizon',
           name: 'Grand Horizon',
           text_in_run:
             'Event Horizon radius 20 ft and lasts until the end of your next turn. The first time each round a creature is stunned by it, you gain 1 Malice.',
@@ -429,6 +465,7 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'morvox_power_overwhelming',
+          effectId: 'morvox_power_overwhelming',
           name: 'Power Overwhelming',
           text_in_run:
             'Max Malice 12; when you spend Malice on a spell, you may spend up to 5. On a takedown, refund 2 Malice.',
@@ -436,6 +473,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'morvox_cataclysm',
+          effectId: 'morvox_cataclysm',
           name: 'Cataclysm (1/SR)',
           text_in_run:
             'Primordial Burst becomes a Bonus Action and doesn’t consume Malice. Against targets at ½ HP or less, the save is made at disadvantage.',
@@ -462,6 +500,7 @@ var AncestorRegistry = (function () {
       Common: [
         {
           id: 'seraphine_kindled_gaze',
+          effectId: 'seraphine_kindled_gaze',
           name: 'Kindled Gaze',
           text_in_run:
             'When you Vent, choose a creature in the area; it takes +PB fire damage if it fails the save.',
@@ -469,6 +508,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'seraphine_coalstrider',
+          effectId: 'seraphine_coalstrider',
           name: 'Coalstrider',
           text_in_run:
             'While you have ≥20 Heat, ignore difficult terrain and you can move through spaces occupied by creatures without provoking OAs.',
@@ -478,6 +518,7 @@ var AncestorRegistry = (function () {
       Greater: [
         {
           id: 'seraphine_cinderstorm',
+          effectId: 'seraphine_cinderstorm',
           name: 'Cinderstorm',
           text_in_run:
             'Fireball ignites the area into Cinder Terrain for 1 minute (1d6 fire on enter/start). Creatures that fail the save are also pushed 5 ft and take +PB fire.',
@@ -485,6 +526,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'seraphine_rolling_furnace',
+          effectId: 'seraphine_rolling_furnace',
           name: 'Rolling Furnace',
           text_in_run:
             'flaming sphere: Once per turn you may move the sphere up to 15 ft when you Vent (no extra action). The sphere deals +PB fire, and creatures that fail its save are pushed 5 ft.',
@@ -494,6 +536,7 @@ var AncestorRegistry = (function () {
       Signature: [
         {
           id: 'seraphine_inferno_combo',
+          effectId: 'seraphine_inferno_combo',
           name: 'Inferno Combo',
           text_in_run:
             'When you take the Attack action with the staff, make a third staff attack.',
@@ -501,6 +544,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'seraphine_phoenix_bloom',
+          effectId: 'seraphine_phoenix_bloom',
           name: 'Phoenix Bloom (1/SR)',
           text_in_run:
             'Instantly Overheat and make two staff attacks. Then refund 25 Heat and move 10 ft without provoking.',
@@ -508,6 +552,7 @@ var AncestorRegistry = (function () {
         },
         {
           id: 'seraphine_phoenix_coronation',
+          effectId: 'seraphine_phoenix_coronation',
           name: 'Phoenix Coronation (1/SR)',
           text_in_run:
             'Empower a major burn: Fireball — after it resolves, the 20-ft radius edge becomes a Cinder Ring for 1 minute (ignited terrain; 1d6 fire on enter/start). Immolation — if the target dies while burning, the flames jump to a new creature within 15 ft (new save; remaining duration). This casting ignores fire resistance and treats immunity as resistance.',

--- a/src/modules/boonManager.js
+++ b/src/modules/boonManager.js
@@ -510,8 +510,6 @@ var BoonManager = (function () {
         if (pool && pool.length) {
           chosen = pickFromPool(pool, order[j], seen, bannedMap);
           if (chosen) {
-            chosen._rarity = order[j];
-            chosen._idx = picks.length;
             break;
           }
         }
@@ -520,7 +518,18 @@ var BoonManager = (function () {
       if (!chosen) {
         break;
       }
-      picks.push(chosen);
+
+      var picked = JSON.parse(JSON.stringify(chosen));
+      picked._rarity = order[j];
+      picked._idx = picks.length;
+      if (!picked.effectId && chosen.effectId) {
+        picked.effectId = chosen.effectId;
+      }
+      if (!picked.effectId && picked.id) {
+        picked.effectId = picked.id;
+      }
+
+      picks.push(picked);
     }
 
     rememberHistory(playerid, picks);
@@ -582,6 +591,7 @@ var BoonManager = (function () {
     ps.boons.push({
       id: picked.id || picked.name,
       name: picked.name,
+      effectId: picked.effectId || picked.id || picked.name,
       rarity: rarity,
       ancestor: offer.ancestor,
       acquiredAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add `effectId` metadata to each ancestor boon so entries align with the effect registry
- ensure drawn boon records clone their source data while preserving the associated `effectId`
- persist the effect identifier when players accept a boon for downstream effect engine use

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4a21206c0832ebf4331cf1c59154d