### PR TITLE
fix: avoid fallback to banned boon cards

### DIFF
--- a/src/modules/boonManager.js
+++ b/src/modules/boonManager.js
@@ -291,7 +291,7 @@ var BoonManager = (function () {
       return fallback.card;
     }
 
-    return pool.splice(0, 1)[0] || null;
+    return null;
   }
 
   function getPlayerName(playerid) {


### PR DESCRIPTION
## Summary
- stop `pickFromPool` from falling back to the first card when every option is banned

## Testing
- not run (Roll20 sandbox)

------
https://chatgpt.com/codex/tasks/task_e_68e4a285ba74832eb1392b1727e59e66