### PR TITLE
fix: allow rerolling unclaimed boon cards

### DIFF
--- a/src/modules/boonManager.js
+++ b/src/modules/boonManager.js
@@ -223,6 +223,10 @@ var BoonManager = (function () {
   }
 
   function rememberHistory(playerid, cards) {
+    // Track only the boons the player actually claimed so future draws
+    // avoid repeating permanent acquisitions. We intentionally skip
+    // recording previewed cards so the same options can surface again
+    // if the player declined them earlier.
     var history = getPlayerHistory(playerid);
     var limit = 24;
     (cards || []).forEach(function (card) {
@@ -532,7 +536,6 @@ var BoonManager = (function () {
       picks.push(picked);
     }
 
-    rememberHistory(playerid, picks);
     return picks;
   }
 


### PR DESCRIPTION
## Summary
- stop recording previewed boon cards in the player's history
- document that boon history only tracks claimed cards to allow repeats of declined options

## Testing
- not run (roll20 sandbox automation only)


------
https://chatgpt.com/codex/tasks/task_e_68e4acb7c4f4832ea5a077c609476c96