### PR TITLE
fix: refresh Vladren kit actions when boons apply

### DIFF
--- a/src/modules/effectRegistry.js
+++ b/src/modules/effectRegistry.js
@@ -82,6 +82,8 @@ var EffectRegistry = (function () {
         // Transfusion +1d8 necrotic; on a kill, refresh Transfusion
         { type: 'attr', name: 'hr_transfusion_bonus_die', op: 'set', value: '1d8' },
         { type: 'attr', name: 'hr_transfusion_refresh_on_kill', op: 'set', value: 1 },
+        { type: 'ability', name: '[Vladren] Transfusion (Bonus)', token: true,
+          action: '&{template:default} {{name=Transfusion (Bonus; 60 ft; Con save)}} {{Save DC=[[ @{selected|spell_save_dc} ]]}} {{Damage=[[ 2d8 + @{selected|hr_pb} + 1d8 ]] necrotic (half on success)}} {{Bloodied bonus=If target ≤ 1/2 HP, add [[ 1d8 ]] necrotic (stacks with this boon)}} {{Refresh=On a kill, refresh Transfusion; use it again this turn.}} {{Heal yourself=Equal to total necrotic dealt}}' },
         { type: 'ability', name: '[Vladren] Crimson Drip (Info)', token: true,
           action: '&{template:default} {{name=Crimson Drip}} {{Transfusion=Deals **+1d8 necrotic**; on a kill, Transfusion is refreshed and can be used again this turn}}' },
         { type: 'note', text: 'Transfusion +1d8 necrotic; refresh on kill (extra use this turn).' }
@@ -109,6 +111,8 @@ var EffectRegistry = (function () {
         // Sanguine Pool gains +15 ft move on enter; recharges on 5–6 if THP >=10
         { type: 'attr', name: 'hr_pool_bonus_move_on_enter', op: 'set', value: 15 },
         { type: 'attr', name: 'hr_pool_recharge_5_6_if_thp10', op: 'set', value: 1 },
+        { type: 'ability', name: '[Vladren] Sanguine Pool (Reaction • 1/SR)', token: true,
+          action: '&{template:default} {{name=Sanguine Pool (Reaction • 1/SR)}} {{Effect=Until the start of your next turn you are blood mist: resistance to all damage; move through creatures; cannot cast leveled spells or make attacks; enemies cannot make OAs against you.}} {{On enter=When you enter the Pool, gain **+15 ft** movement.}} {{Recharge=At the start of your turn, recharge on a **5–6** while you have **≥10 temp HP**.}}' },
         { type: 'ability', name: '[Vladren] Sovereign Pool (Info)', token: false,
           action: '&{template:default} {{name=Sovereign Pool}} {{Move=When you enter, gain **+15 ft** movement}} {{Recharge=At start of your turn, **recharges on 5–6** while you have **≥10 temp HP**}}' },
         { type: 'note', text: 'Pool: +15 ft move on enter; recharge on 5–6 while you have ≥10 temp HP.' }
@@ -140,6 +144,8 @@ var EffectRegistry = (function () {
         { type: 'attr', name: 'hr_hemo_plague_bonus_damage', op: 'set', value: '2d6' },
         { type: 'attr', name: 'hr_necrotic_dc_bonus', op: 'set', value: 1 },
         { type: 'attr', name: 'hr_adv_vs_plagued', op: 'set', value: 1 },
+        { type: 'ability', name: '[Vladren] Hemoplague (1/SR)', token: true,
+          action: '&{template:default} {{name=Hemoplague (1/SR; 20-ft; 60 ft; Con save)}} {{Plagued=Target is <b>Plagued</b> until end of its next turn (takes <b>+@{selected|hr_pb}</b> damage from all sources) and is <b>vulnerable to necrotic</b> until the burst resolves.}} {{Burst=Then take [[ 6d6 + 2d6 ]] necrotic (success [[ 3d6 + 2d6 ]] necrotic).}} {{Dominance=While a creature is Plagued, you have advantage on attacks and +1 to spell save DC against it.}} {{Heal yourself=Equal to necrotic dealt; excess becomes Pact temp HP.}}' },
         { type: 'ability', name: '[Vladren] Hemarch\u2019s Decree (Info)', token: true,
           action: '&{template:default} {{name=Hemarch’s Decree}} {{Hemoplague=Targets are **vulnerable to necrotic** until the burst}} {{Burst=Burst deals **+2d6 necrotic**}} {{Targeting=You have **advantage** on attacks and **+1** to spell save DC vs **Plagued** creatures}}' },
         { type: 'note', text: 'Hemoplague: necrotic vuln; burst +2d6 necrotic; +1 DC & advantage vs Plagued.' }


### PR DESCRIPTION
## Summary
- preserve mirrored token action flags when applying ability patches
- update Vladren boons to rewrite their kit abilities with boon-enhanced roll templates

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e4b3938460832e971c7f7dec0a684d