### PR TITLE
fix: ensure resetstate clears generated handouts

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -18,7 +18,7 @@
 - `!tradeSquares scrip|fse` — Convert Squares into the specified currency reward.
 
 ## Developer Utilities (GM Only)
-- `!resetstate` — Wipe all Hoard Run data and purge mirrored kit abilities from player sheets.
+- `!resetstate` — Wipe all Hoard Run data, purge mirrored kit abilities, and remove generated handouts.
 - `!debugstate [playerName|playerId]` — Whisper the current Hoard Run state block (optionally filtered to a player).
 - `!testshop` — Generate a mock Bing, Bang & Bongo shop for the first online player.
 - `!testrelic` — Roll a random relic using DeckManager (falls back to static data if decks are missing).

--- a/src/modules/devTools.js
+++ b/src/modules/devTools.js
@@ -28,6 +28,7 @@ var DevTools = (function () {
     if (typeof AncestorKits !== 'undefined' && AncestorKits && typeof AncestorKits.clearAllMirroredAbilities === 'function') {
       AncestorKits.clearAllMirroredAbilities();
     }
+    resetHandouts();
     delete state.HoardRun;
     state.HoardRun = { players: {}, version: 'dev' };
     if (typeof RunFlowManager !== 'undefined' && typeof RunFlowManager.resetRunState === 'function') {


### PR DESCRIPTION
## Summary
- call the existing handout cleanup helper when !resetstate runs
- document that the reset command now removes generated handouts

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e5d4eb7580832e97f72fea020f77d8