### PR TITLE
Add Roll20 effect adapter support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,7 @@ on('ready', function () {
     'StateManager',
     'DeckManager',
     'UIManager',
+    'EffectAdapters',
     'EffectRegistry',
     'EffectEngine',
     'BoonDataLoader',

--- a/src/modules/effectAdapters.dnd5e.roll20.js
+++ b/src/modules/effectAdapters.dnd5e.roll20.js
@@ -1,0 +1,412 @@
+// ------------------------------------------------------------
+// Effect Adapter — D&D 5e by Roll20
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Provides sheet-specific logic for the Roll20 5e sheet.
+//   Adds and removes repeating global modifiers and namespaced
+//   attributes so Hoard Run effects can patch attacks and DCs.
+// ------------------------------------------------------------
+
+(function () {
+  if (typeof EffectAdapters === 'undefined' || !EffectAdapters || typeof EffectAdapters.registerAdapter !== 'function') {
+    return;
+  }
+
+  function randRowId() {
+    var charset = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    var output = '-';
+    for (var i = 0; i < 19; i++) {
+      var idx = Math.floor(Math.random() * charset.length);
+      output += charset.charAt(idx);
+    }
+    return output;
+  }
+
+  function setAttr(charId, name, value) {
+    var attr = findObjs({
+      _type: 'attribute',
+      _characterid: charId,
+      name: name
+    })[0];
+
+    if (!attr) {
+      attr = createObj('attribute', {
+        _characterid: charId,
+        name: name,
+        current: value
+      });
+    } else {
+      attr.set('current', value);
+    }
+
+    return attr;
+  }
+
+  function getAttr(charId, name) {
+    var attr = findObjs({
+      _type: 'attribute',
+      _characterid: charId,
+      name: name
+    })[0];
+
+    if (!attr) {
+      return '';
+    }
+
+    var current = attr.get('current');
+    return typeof current === 'undefined' || current === null ? '' : current;
+  }
+
+  function addNumber(charId, name, delta) {
+    var attr = findObjs({
+      _type: 'attribute',
+      _characterid: charId,
+      name: name
+    })[0];
+
+    if (!attr) {
+      attr = createObj('attribute', {
+        _characterid: charId,
+        name: name,
+        current: 0
+      });
+    }
+
+    var current = parseFloat(attr.get('current'));
+    if (isNaN(current)) {
+      current = 0;
+    }
+
+    var change = parseFloat(delta);
+    if (isNaN(change)) {
+      change = 0;
+    }
+
+    attr.set('current', current + change);
+  }
+
+  function rememberRowId(charId, key, rowId) {
+    var existing = String(getAttr(charId, key) || '');
+    var list = existing ? existing.split('|') : [];
+    var already = false;
+
+    for (var i = 0; i < list.length; i++) {
+      if (list[i] === rowId) {
+        already = true;
+        break;
+      }
+    }
+
+    if (!already) {
+      list.push(rowId);
+    }
+
+    setAttr(charId, key, list.join('|'));
+  }
+
+  function readRowIds(charId, key) {
+    var raw = String(getAttr(charId, key) || '');
+    var parts = raw ? raw.split('|') : [];
+    var ids = [];
+
+    for (var i = 0; i < parts.length; i++) {
+      if (parts[i]) {
+        ids.push(parts[i]);
+      }
+    }
+
+    return ids;
+  }
+
+  function clearRowIds(charId, key) {
+    setAttr(charId, key, '');
+  }
+
+  function removeRepeatingRow(charId, section, rowId) {
+    var prefix = 'repeating_' + section + '_' + rowId + '_';
+    var attrs = findObjs({
+      _type: 'attribute',
+      _characterid: charId
+    }) || [];
+
+    for (var i = 0; i < attrs.length; i++) {
+      var attr = attrs[i];
+      var name = attr.get('name') || '';
+      if (name.indexOf(prefix) === 0) {
+        try {
+          attr.remove();
+        } catch (err) {
+          // Ignore removal issues; sandbox may throw if already deleted.
+        }
+      }
+    }
+  }
+
+  function ensureGlobalRow(charId, section, fields, rememberKey) {
+    try {
+      var rowId = randRowId();
+      for (var field in fields) {
+        if (fields.hasOwnProperty(field)) {
+          var attrName = 'repeating_' + section + '_' + rowId + '_' + field;
+          setAttr(charId, attrName, fields[field]);
+        }
+      }
+      if (rememberKey) {
+        rememberRowId(charId, rememberKey, rowId);
+      }
+      return { ok: true, rowId: rowId };
+    } catch (err) {
+      sendChat('Adapter', '/w gm Failed to create repeating_' + section + ' row: ' + err.message);
+      return { ok: false };
+    }
+  }
+
+  function applyPatch(charId, patch) {
+    if (!patch || patch.type !== 'adapter' || !patch.op) {
+      return false;
+    }
+
+    if (patch.op === 'add_ac_misc') {
+      addNumber(charId, 'hr_adapter_ac_misc_total', patch.value || 0);
+      return true;
+    }
+
+    if (patch.op === 'add_speed_bonus') {
+      addNumber(charId, 'hr_speed_bonus_total', patch.value || 0);
+      return true;
+    }
+
+    if (patch.op === 'add_global_spell_attack') {
+      var attackValue = Number(patch.value || 0);
+      var attackString = (attackValue >= 0 ? '+' : '') + attackValue;
+
+      var attackRow = ensureGlobalRow(charId, 'attackmod', {
+        'global_attack_name': 'Hoard: Spell Attacks ' + attackString,
+        'global_attack_attack': attackString,
+        'global_attack_roll': 'on'
+      }, 'hr_rows_attackmod');
+
+      if (attackRow.ok) {
+        return true;
+      }
+
+      var legacyAttack = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'global_spell_attack_bonus'
+      })[0];
+
+      if (legacyAttack) {
+        var curAttack = String(legacyAttack.get('current') || '').trim();
+        legacyAttack.set('current', curAttack ? curAttack + ' ' + attackString : attackString);
+        return true;
+      }
+
+      addNumber(charId, 'hr_spell_attack_bonus_total', attackValue);
+      return true;
+    }
+
+    if (patch.op === 'add_global_save_dc') {
+      var saveValue = Number(patch.value || 0);
+      var saveString = (saveValue >= 0 ? '+' : '') + saveValue;
+
+      var saveRow = ensureGlobalRow(charId, 'savemod', {
+        'global_save_name': 'Hoard: Spell DC ' + saveString,
+        'global_save_bonus': saveString,
+        'global_save_roll': 'on'
+      }, 'hr_rows_savemod');
+
+      if (saveRow.ok) {
+        return true;
+      }
+
+      var legacySave = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'global_spell_dc_bonus'
+      })[0];
+
+      if (legacySave) {
+        var curSave = String(legacySave.get('current') || '').trim();
+        legacySave.set('current', curSave ? curSave + ' ' + saveString : saveString);
+        return true;
+      }
+
+      addNumber(charId, 'hr_spell_dc_bonus_total', saveValue);
+      return true;
+    }
+
+    if (patch.op === 'add_resource_counter') {
+      var base = 'hr_res_' + String(patch.name || 'resource').replace(/[^a-z0-9]/gi, '_').toLowerCase();
+      setAttr(charId, base + '_max', patch.max || 1);
+      setAttr(charId, base + '_cur', patch.max || 1);
+      setAttr(charId, base + '_cadence', patch.cadence || 'per_room');
+      return true;
+    }
+
+    if (patch.op === 'on_kill_refresh') {
+      var list = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_on_kill_hooks'
+      })[0];
+
+      if (!list) {
+        list = createObj('attribute', {
+          _characterid: charId,
+          name: 'hr_on_kill_hooks',
+          current: ''
+        });
+      }
+
+      var existingHooks = list.get('current') || '';
+      var feature = String(patch.feature || 'Feature').replace(/[|]/g, '/');
+      list.set('current', existingHooks ? existingHooks + '|' + feature : feature);
+      return true;
+    }
+
+    if (patch.op === 'add_aura') {
+      var auraName = String(patch.name || 'Aura').replace(/[|]/g, '/');
+      var packed = auraName + '::' + (patch.radius || 10) + '::' + (patch.note || '');
+      setAttr(charId, 'hr_token_aura_cfg', packed);
+      return true;
+    }
+
+    return false;
+  }
+
+  function removePatch(charId, patch) {
+    if (!patch || patch.type !== 'adapter' || !patch.op) {
+      return false;
+    }
+
+    if (patch.op === 'add_ac_misc') {
+      var acAttr = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_adapter_ac_misc_total'
+      })[0];
+      if (acAttr) {
+        acAttr.set('current', 0);
+      }
+      return true;
+    }
+
+    if (patch.op === 'add_speed_bonus') {
+      var speedAttr = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_speed_bonus_total'
+      })[0];
+      if (speedAttr) {
+        speedAttr.set('current', 0);
+      }
+      return true;
+    }
+
+    if (patch.op === 'add_global_spell_attack') {
+      var attackIds = readRowIds(charId, 'hr_rows_attackmod');
+      for (var i = 0; i < attackIds.length; i++) {
+        removeRepeatingRow(charId, 'attackmod', attackIds[i]);
+      }
+      clearRowIds(charId, 'hr_rows_attackmod');
+
+      var attackTotal = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_spell_attack_bonus_total'
+      })[0];
+      if (attackTotal) {
+        attackTotal.set('current', 0);
+      }
+      return true;
+    }
+
+    if (patch.op === 'add_global_save_dc') {
+      var saveIds = readRowIds(charId, 'hr_rows_savemod');
+      for (var j = 0; j < saveIds.length; j++) {
+        removeRepeatingRow(charId, 'savemod', saveIds[j]);
+      }
+      clearRowIds(charId, 'hr_rows_savemod');
+
+      var saveTotal = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_spell_dc_bonus_total'
+      })[0];
+      if (saveTotal) {
+        saveTotal.set('current', 0);
+      }
+      return true;
+    }
+
+    if (patch.op === 'add_resource_counter') {
+      var baseName = 'hr_res_' + String(patch.name || 'resource').replace(/[^a-z0-9]/gi, '_').toLowerCase();
+      var suffixes = ['_max', '_cur', '_cadence'];
+      for (var k = 0; k < suffixes.length; k++) {
+        var attr = findObjs({
+          _type: 'attribute',
+          _characterid: charId,
+          name: baseName + suffixes[k]
+        })[0];
+        if (attr) {
+          try {
+            attr.remove();
+          } catch (err) {
+            // Ignore removal failures; attribute may already be gone.
+          }
+        }
+      }
+      return true;
+    }
+
+    if (patch.op === 'on_kill_refresh') {
+      return true;
+    }
+
+    if (patch.op === 'add_aura') {
+      var auraCfg = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'hr_token_aura_cfg'
+      })[0];
+      if (auraCfg) {
+        try {
+          auraCfg.remove();
+        } catch (err) {
+          // Ignore failures; attribute might be locked by sandbox conditions.
+        }
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  EffectAdapters.registerAdapter({
+    name: 'dnd5e-roll20',
+    detect: function (character) {
+      var charId = character ? character.id : null;
+      if (!charId) {
+        return false;
+      }
+      var pb = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'pb'
+      })[0];
+      var sca = findObjs({
+        _type: 'attribute',
+        _characterid: charId,
+        name: 'spellcasting_ability'
+      })[0];
+      return !!(pb || sca);
+    },
+    apply: function (charId, patch) {
+      return applyPatch(charId, patch);
+    },
+    remove: function (charId, patch) {
+      return removePatch(charId, patch);
+    }
+  });
+})();

--- a/src/modules/effectAdapters.js
+++ b/src/modules/effectAdapters.js
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------
+// Effect Adapters
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   Maintains a registry of Roll20 sheet adapters.
+//   Adapters abstract sheet-specific logic for applying Hoard
+//   patches so the effect engine can stay sheet-agnostic.
+// ------------------------------------------------------------
+
+var EffectAdapters = (function () {
+  var root = (typeof globalThis !== 'undefined') ? globalThis : this;
+  var logger = root.HRLog || null;
+  var adapters = [];
+
+  function info(message) {
+    if (logger && typeof logger.info === 'function') {
+      logger.info('EffectAdapters', message);
+    } else {
+      log('[Hoard Run] [EffectAdapters] ℹ️ ' + message);
+    }
+  }
+
+  function warn(message) {
+    if (logger && typeof logger.warn === 'function') {
+      logger.warn('EffectAdapters', message);
+    } else {
+      log('[Hoard Run] [EffectAdapters] ⚠️ ' + message);
+    }
+  }
+
+  function error(message) {
+    if (logger && typeof logger.error === 'function') {
+      logger.error('EffectAdapters', message);
+    } else {
+      log('[Hoard Run] [EffectAdapters] ❌ ' + message);
+    }
+  }
+
+  function findCharacter(characterId) {
+    if (!characterId) {
+      return null;
+    }
+    var character = getObj('character', characterId);
+    if (!character) {
+      warn('Character ' + characterId + ' not found while resolving adapters.');
+      return null;
+    }
+    return character;
+  }
+
+  function pickAdapter(character) {
+    if (!character) {
+      return null;
+    }
+
+    for (var i = 0; i < adapters.length; i++) {
+      var adapter = adapters[i];
+      try {
+        if (!adapter.detect || adapter.detect(character)) {
+          return adapter;
+        }
+      } catch (err) {
+        error('Adapter "' + (adapter.name || ('#' + i)) + '" detect failed: ' + err);
+      }
+    }
+
+    return null;
+  }
+
+  function registerAdapter(adapter) {
+    if (!adapter || typeof adapter.apply !== 'function') {
+      warn('Attempted to register invalid adapter.');
+      return;
+    }
+
+    adapters.push(adapter);
+    info('Registered adapter "' + (adapter.name || 'unnamed') + '".');
+  }
+
+  function apply(characterId, patch, effect) {
+    var character = findCharacter(characterId);
+    if (!character) {
+      return false;
+    }
+
+    var adapter = pickAdapter(character);
+    if (!adapter) {
+      warn('No adapter available for character ' + character.get('name') + '.');
+      return false;
+    }
+
+    try {
+      return adapter.apply(characterId, patch, effect) === true;
+    } catch (err) {
+      error('Adapter "' + (adapter.name || 'unnamed') + '" apply error: ' + err);
+      return false;
+    }
+  }
+
+  function remove(characterId, patch, effect) {
+    var character = findCharacter(characterId);
+    if (!character) {
+      return false;
+    }
+
+    var adapter = pickAdapter(character);
+    if (!adapter || typeof adapter.remove !== 'function') {
+      warn('No removable adapter available for character ' + character.get('name') + '.');
+      return false;
+    }
+
+    try {
+      return adapter.remove(characterId, patch, effect) === true;
+    } catch (err) {
+      error('Adapter "' + (adapter.name || 'unnamed') + '" remove error: ' + err);
+      return false;
+    }
+  }
+
+  function registerModule() {
+    info('EffectAdapters ready. Registered ' + adapters.length + ' adapters.');
+  }
+
+  return {
+    registerAdapter: registerAdapter,
+    apply: apply,
+    remove: remove,
+    register: registerModule
+  };
+})();

--- a/src/modules/effectEngine.js
+++ b/src/modules/effectEngine.js
@@ -208,6 +208,13 @@ var EffectEngine = (function () {
       if (patch.type === 'note') {
         applyNotePatch(character, effect, patch);
       }
+      if (patch.type === 'adapter') {
+        if (typeof EffectAdapters !== 'undefined' && EffectAdapters && typeof EffectAdapters.apply === 'function') {
+          EffectAdapters.apply(characterId, patch, effect);
+        } else {
+          warn('Adapter patch skipped — EffectAdapters module unavailable.');
+        }
+      }
     }
 
     info('Applied effect "' + (effect.name || effect.id) + '" to character ' + character.get('name') + '.');


### PR DESCRIPTION
## Summary
- add an EffectAdapters module to register and resolve sheet adapters at runtime
- implement the Roll20 D&D 5e adapter with repeating row bookkeeping so global modifiers can be removed cleanly
- wire the effect engine and bootstrap so adapter patches are applied alongside existing attr, ability, and note patches

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5e2591fbc832e9596360eac35c407