### PR TITLE
fix: clear boon token actions during reset

### DIFF
--- a/src/modules/devTools.js
+++ b/src/modules/devTools.js
@@ -25,6 +25,13 @@ var DevTools = (function () {
    * Clears all progress, currencies, boons, etc.
    */
   function resetState() {
+    if (
+      typeof EffectEngine !== 'undefined' &&
+      EffectEngine &&
+      typeof EffectEngine.removeTokenAbilitiesFromRunState === 'function'
+    ) {
+      EffectEngine.removeTokenAbilitiesFromRunState();
+    }
     if (typeof AncestorKits !== 'undefined' && AncestorKits && typeof AncestorKits.clearAllMirroredAbilities === 'function') {
       AncestorKits.clearAllMirroredAbilities();
     }

--- a/src/modules/effectEngine.js
+++ b/src/modules/effectEngine.js
@@ -173,6 +173,141 @@ var EffectEngine = (function () {
     upsertAbility(characterId, name, action, tokenAction, ability);
   }
 
+  function removeTokenAbilityByName(characterId, abilityName) {
+    if (!characterId || !abilityName) {
+      return 0;
+    }
+    if (typeof findObjs !== 'function') {
+      return 0;
+    }
+
+    var removed = 0;
+    var matches = findObjs({
+      _type: 'ability',
+      _characterid: characterId,
+      name: abilityName
+    }) || [];
+
+    for (var i = 0; i < matches.length; i += 1) {
+      var ability = matches[i];
+      if (!ability) {
+        continue;
+      }
+
+      var isTokenAction = false;
+      try {
+        if (typeof ability.get === 'function') {
+          isTokenAction = !!ability.get('istokenaction');
+        }
+      } catch (abilityErr) {}
+
+      if (!isTokenAction) {
+        continue;
+      }
+
+      try {
+        if (typeof ability.remove === 'function') {
+          ability.remove();
+          removed += 1;
+        }
+      } catch (removeErr) {}
+    }
+
+    return removed;
+  }
+
+  function removeTokenAbilityPatch(characterId, patch) {
+    if (!patch || patch.type !== 'ability') {
+      return 0;
+    }
+
+    var hasTokenFlag = Object.prototype.hasOwnProperty.call(patch, 'token');
+    if (!hasTokenFlag || !patch.token) {
+      return 0;
+    }
+
+    var abilityName = patch.name || patch.label;
+    if (!abilityName) {
+      return 0;
+    }
+
+    return removeTokenAbilityByName(characterId, abilityName);
+  }
+
+  function removeTokenAbilitiesForEffect(characterId, effect) {
+    if (!characterId || !effect) {
+      return 0;
+    }
+
+    var removed = 0;
+    var patches = effect.patches || [];
+
+    for (var i = 0; i < patches.length; i += 1) {
+      removed += removeTokenAbilityPatch(characterId, patches[i]);
+    }
+
+    return removed;
+  }
+
+  function removeTokenAbilitiesFromRunState() {
+    if (typeof state === 'undefined' || !state || !state.HoardRun || !state.HoardRun.players) {
+      return 0;
+    }
+
+    if (typeof EffectRegistry === 'undefined' || !EffectRegistry || typeof EffectRegistry.get !== 'function') {
+      warn('EffectRegistry unavailable; cannot remove token abilities from run state.');
+      return 0;
+    }
+
+    var removed = 0;
+    var players = state.HoardRun.players;
+    var pools = ['boons', 'relics'];
+
+    for (var pid in players) {
+      if (!players.hasOwnProperty(pid)) {
+        continue;
+      }
+
+      var player = players[pid];
+      if (!player || !player.boundCharacterId) {
+        continue;
+      }
+
+      for (var p = 0; p < pools.length; p += 1) {
+        var poolName = pools[p];
+        var list = player[poolName];
+        if (!list || !list.length) {
+          continue;
+        }
+
+        for (var i = 0; i < list.length; i += 1) {
+          var entry = list[i];
+          if (!entry) {
+            continue;
+          }
+
+          var effectId = entry.effectId || entry.effect_id || entry.id || entry.name;
+          if (!effectId) {
+            continue;
+          }
+
+          var effectDef = EffectRegistry.get(effectId);
+          if (!effectDef) {
+            continue;
+          }
+
+          removed += removeTokenAbilitiesForEffect(player.boundCharacterId, effectDef);
+        }
+      }
+    }
+
+    if (removed > 0) {
+      info('Removed ' + removed + ' token abilities from boon or relic effects.');
+    }
+
+    return removed;
+  }
+
   function applyNotePatch(character, effect, patch) {
     appendGMNote(character, effect.name || effect.id || 'Effect', patch.text || '');
   }
@@ -262,6 +397,7 @@ var EffectEngine = (function () {
 
   return {
     apply: apply,
-    register: register
+    register: register,
+    removeTokenAbilitiesFromRunState: removeTokenAbilitiesFromRunState
   };
 })();


### PR DESCRIPTION
## Summary
- add an EffectEngine helper to strip token action abilities granted by boon and relic effects
- invoke the cleanup helper from `!resetstate` so resetting also removes those token buttons

## Testing
- not run (Roll20 sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68e5e6dc31e4832ea6896025f6e2f086