### PR TITLE
Fix token ability cleanup during resets

### DIFF
--- a/src/modules/stateManager.js
+++ b/src/modules/stateManager.js
@@ -142,8 +142,19 @@ var StateManager = (function () {
 
   /** Resets a player's corridor progress and currencies */
   function resetPlayerRun(playerid) {
-    var fresh = cloneDefaultPlayerState();
     init();
+
+    var existing = state.HoardRun.players[playerid] || null;
+    if (
+      existing &&
+      typeof EffectEngine !== 'undefined' &&
+      EffectEngine &&
+      typeof EffectEngine.removeTokenAbilitiesForPlayer === 'function'
+    ) {
+      EffectEngine.removeTokenAbilitiesForPlayer(existing);
+    }
+
+    var fresh = cloneDefaultPlayerState();
     state.HoardRun.players[playerid] = fresh;
     return state.HoardRun.players[playerid];
   }


### PR DESCRIPTION
## Summary
- add a reusable helper in `EffectEngine` to strip token actions for a player's stored effects
- call the helper when resetting a player so boon token actions are cleared before state is wiped
- reuse the helper in the run-wide cleanup to keep logic centralized

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5eb56aac4832ea823bf004a9171b5