### PR TITLE
Fix token ability cleanup during resets

### DIFF
--- a/src/modules/effectEngine.js
+++ b/src/modules/effectEngine.js
@@ -249,6 +249,269 @@ var EffectEngine = (function () {
     return removed;
   }
 
+  function slugify(text) {
+    if (!text) {
+      return '';
+    }
+
+    return String(text)
+      .toLowerCase()
+      .replace(/[\u2019'`]+/g, '')
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+
+  function firstSlugSegment(text) {
+    var slug = slugify(text);
+    if (!slug) {
+      return '';
+    }
+
+    return slug.split('_')[0];
+  }
+
+  function buildEffectIdCandidates(entry) {
+    var candidates = [];
+    var seen = {};
+
+    function pushCandidate(value) {
+      if (!value) {
+        return;
+      }
+
+      var lowered = String(value).toLowerCase();
+      if (seen[lowered]) {
+        return;
+      }
+
+      seen[lowered] = true;
+      candidates.push(value);
+    }
+
+    if (entry) {
+      pushCandidate(entry.effectId);
+      pushCandidate(entry.effect_id);
+      pushCandidate(entry.id);
+      pushCandidate(entry.name);
+    }
+
+    var ancestor = entry && entry.ancestor ? entry.ancestor : (entry && entry.source ? entry.source : null);
+    var ancestorSlug = ancestor ? firstSlugSegment(ancestor) : '';
+    var entrySlug = entry ? slugify(entry.effectId || entry.id || entry.name) : '';
+
+    if (entrySlug) {
+      pushCandidate(entrySlug);
+      if (ancestorSlug) {
+        pushCandidate(ancestorSlug + '_' + entrySlug);
+      }
+    }
+
+    return candidates;
+  }
+
+  function resolveEffectDefinition(entry) {
+    var candidates = buildEffectIdCandidates(entry);
+
+    for (var i = 0; i < candidates.length; i += 1) {
+      var candidate = candidates[i];
+      var effect = getEffectDefinition(candidate);
+      if (effect) {
+        return effect;
+      }
+    }
+
+    return null;
+  }
+
+  function collectTokenAbilities(characterId) {
+    if (!characterId || typeof findObjs !== 'function') {
+      return [];
+    }
+
+    var abilities = findObjs({
+      _type: 'ability',
+      _characterid: characterId
+    }) || [];
+
+    var results = [];
+
+    for (var i = 0; i < abilities.length; i += 1) {
+      var ability = abilities[i];
+      if (!ability) {
+        continue;
+      }
+
+      var isToken = false;
+
+      try {
+        if (typeof ability.get === 'function') {
+          isToken = !!ability.get('istokenaction');
+        }
+      } catch (abilityErr) {}
+
+      if (isToken) {
+        results.push(ability);
+      }
+    }
+
+    return results;
+  }
+
+  function removeTokenAbilitiesByPrefix(characterId, prefixes, abilityCache) {
+    if (!characterId || !prefixes || !prefixes.length) {
+      return 0;
+    }
+
+    var removed = 0;
+    var normalized = [];
+
+    for (var p = 0; p < prefixes.length; p += 1) {
+      var prefix = prefixes[p];
+      if (!prefix) {
+        continue;
+      }
+      normalized.push(String(prefix).toLowerCase());
+    }
+
+    if (!normalized.length) {
+      return 0;
+    }
+
+    var list = abilityCache || collectTokenAbilities(characterId);
+
+    for (var i = 0; i < list.length; i += 1) {
+      var ability = list[i];
+      if (!ability) {
+        continue;
+      }
+
+      var name = '';
+
+      try {
+        if (typeof ability.get === 'function') {
+          name = ability.get('name') || '';
+        }
+      } catch (nameErr) {}
+
+      var lowered = String(name).toLowerCase();
+      if (!lowered) {
+        continue;
+      }
+
+      for (var n = 0; n < normalized.length; n += 1) {
+        var token = normalized[n];
+        if (!token) {
+          continue;
+        }
+
+        if (lowered.indexOf(token) === 0) {
+          try {
+            if (typeof ability.remove === 'function') {
+              ability.remove();
+              removed += 1;
+              list[i] = null;
+            }
+          } catch (removeErr) {}
+          break;
+        }
+      }
+    }
+
+    return removed;
+  }
+
+  function buildTokenPrefixes(entry) {
+    var prefixes = [];
+    if (!entry) {
+      return prefixes;
+    }
+
+    var ancestor = entry.ancestor || entry.source;
+    if (ancestor) {
+      var first = firstSlugSegment(ancestor);
+      if (first) {
+        prefixes.push('[' + first + ']');
+      }
+    }
+
+    var effectId = entry.effectId || entry.effect_id || entry.id || entry.name;
+    if (effectId) {
+      var seg = firstSlugSegment(effectId);
+      if (seg) {
+        prefixes.push('[' + seg + ']');
+      }
+    }
+
+    return prefixes;
+  }
+
+  function getEffectDefinition(effectId) {
+    if (!effectId) {
+      return null;
+    }
+
+    if (typeof EffectRegistry === 'undefined' || !EffectRegistry || typeof EffectRegistry.get !== 'function') {
+      return null;
+    }
+
+    return EffectRegistry.get(effectId);
+  }
+
+  function removeTokenAbilitiesForPlayer(playerState) {
+    if (!playerState || !playerState.boundCharacterId) {
+      return 0;
+    }
+
+    var removed = 0;
+    var pools = ['boons', 'relics'];
+    var abilityCache = null;
+
+    for (var p = 0; p < pools.length; p += 1) {
+      var poolName = pools[p];
+      var list = playerState[poolName];
+      if (!list || !list.length) {
+        continue;
+      }
+
+      for (var i = 0; i < list.length; i += 1) {
+        var entry = list[i];
+        if (!entry) {
+          continue;
+        }
+
+        var effectDef = resolveEffectDefinition(entry);
+        var removedForEntry = 0;
+
+        if (effectDef) {
+          removedForEntry = removeTokenAbilitiesForEffect(playerState.boundCharacterId, effectDef);
+        }
+
+        if (!removedForEntry) {
+          if (!effectDef) {
+            warn('Effect definition missing for entry "' + (entry.name || entry.id || entry.effectId || 'Unknown') + '"; attempting fallback removal.');
+          }
+          if (!abilityCache) {
+            abilityCache = collectTokenAbilities(playerState.boundCharacterId);
+          }
+
+          var prefixes = buildTokenPrefixes(entry);
+          var fallbackRemoved = removeTokenAbilitiesByPrefix(playerState.boundCharacterId, prefixes, abilityCache);
+
+          if (fallbackRemoved > 0) {
+            removedForEntry += fallbackRemoved;
+            info('Removed ' + fallbackRemoved + ' token abilities using prefix fallback for "' + (entry.name || entry.id || entry.effectId || 'Unknown') + '".');
+          }
+        } else {
+          abilityCache = null;
+        }
+
+        removed += removedForEntry;
+      }
+    }
+
+    return removed;
+  }
+
   function removeTokenAbilitiesFromRunState() {
     if (typeof state === 'undefined' || !state || !state.HoardRun || !state.HoardRun.players) {
       return 0;
@@ -261,44 +524,13 @@ var EffectEngine = (function () {
 
     var removed = 0;
     var players = state.HoardRun.players;
-    var pools = ['boons', 'relics'];
 
     for (var pid in players) {
       if (!players.hasOwnProperty(pid)) {
         continue;
       }
 
-      var player = players[pid];
-      if (!player || !player.boundCharacterId) {
-        continue;
-      }
-
-      for (var p = 0; p < pools.length; p += 1) {
-        var poolName = pools[p];
-        var list = player[poolName];
-        if (!list || !list.length) {
-          continue;
-        }
-
-        for (var i = 0; i < list.length; i += 1) {
-          var entry = list[i];
-          if (!entry) {
-            continue;
-          }
-
-          var effectId = entry.effectId || entry.effect_id || entry.id || entry.name;
-          if (!effectId) {
-            continue;
-          }
-
-          var effectDef = EffectRegistry.get(effectId);
-          if (!effectDef) {
-            continue;
-          }
-
-          removed += removeTokenAbilitiesForEffect(player.boundCharacterId, effectDef);
-        }
-      }
+      removed += removeTokenAbilitiesForPlayer(players[pid]);
     }
 
     if (removed > 0) {
@@ -398,6 +630,7 @@ var EffectEngine = (function () {
   return {
     apply: apply,
     register: register,
+    removeTokenAbilitiesForPlayer: removeTokenAbilitiesForPlayer,
     removeTokenAbilitiesFromRunState: removeTokenAbilitiesFromRunState
   };
 })();

--- a/src/modules/stateManager.js
+++ b/src/modules/stateManager.js
@@ -142,8 +142,19 @@ var StateManager = (function () {
 
   /** Resets a player's corridor progress and currencies */
   function resetPlayerRun(playerid) {
-    var fresh = cloneDefaultPlayerState();
     init();
+
+    var existing = state.HoardRun.players[playerid] || null;
+    if (
+      existing &&
+      typeof EffectEngine !== 'undefined' &&
+      EffectEngine &&
+      typeof EffectEngine.removeTokenAbilitiesForPlayer === 'function'
+    ) {
+      EffectEngine.removeTokenAbilitiesForPlayer(existing);
+    }
+
+    var fresh = cloneDefaultPlayerState();
     state.HoardRun.players[playerid] = fresh;
     return state.HoardRun.players[playerid];
   }


### PR DESCRIPTION
## Summary
- add slug-based helpers in `EffectEngine` to resolve effect definitions from legacy boon state data
- fall back to prefix-based token ability scans when explicit effect data is missing so lingering `[Vladren]` actions are removed

## Testing
- not run (Roll20 sandbox unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5eb56aac4832ea823bf004a9171b5