### PR TITLE
fix: change kit charges to per room

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -24,6 +24,6 @@
 - `!testrelic` — Roll a random relic using DeckManager (falls back to static data if decks are missing).
 - `!resethandouts` — Delete Hoard Run-generated handouts (boons, relics, kits) so journals are clean before a reset.
 - `!givevladren` — Installs the Vladren Moroi kit on the issuing GM for testing the ancestor token actions.
-- `!resetvladren` — Resets short-rest charges for Vladren Moroi features on the issuing GM.
+- `!resetvladren` — Resets per-room charges for Vladren Moroi features on the issuing GM.
 - `!bindvladren` — Mirrors Vladren Moroi's token action buttons onto the currently selected PC (GM only).
 - `!bindkit <Ancestor>` — (GM only) Mirrors the registered Ancestor kit abilities onto the selected PC token using `AncestorKits`. The mirrored macros live on the sheet's **Attributes & Abilities** tab and show up as token action buttons for that character.

--- a/src/modules/ancestorKits.vladren.js
+++ b/src/modules/ancestorKits.vladren.js
@@ -32,8 +32,8 @@
   var KIT_RULES_HTML = [
     '<b>Crimson Pact.</b> Excess healing becomes <b>temp HP</b> (cap <b>5×PB + spell mod</b>). While you have Pact temp HP: <b>+1 AC</b>; your <b>necrotic ignores resistance</b> (treat immunity as resistance).',
     '<b>Transfusion (Bonus, 1/turn).</b> One creature within <b>60 ft</b> makes a <b>Con save</b>. Fail: <b>2d8 necrotic + PB</b> (success half). You <b>heal</b> for the damage dealt. If the target is <b>½ HP or less</b>, Transfusion deals <b>+1d8 necrotic</b>.',
-    '<b>Sanguine Pool (Reaction, 1/SR).</b> When you take damage, become <b>blood mist</b> until the start of your next turn: <b>resistance to all</b>, you can <b>move through creatures</b>, you <b>can’t cast leveled spells or make attacks</b>, and <b>enemies can’t make OAs</b> against you.',
-    '<b>Hemoplague (1/SR).</b> <b>20-ft radius</b> point within 60 ft, Con save → target is <b>Plagued</b> until end of next turn (<b>+PB damage</b> from all sources), then it takes <b>6d6 necrotic</b> (success <b>3d6</b>). You <b>heal</b> for the total necrotic; excess healing becomes <b>Pact temp HP</b>.'
+    '<b>Sanguine Pool (Reaction, 1/room).</b> When you take damage, become <b>blood mist</b> until the start of your next turn: <b>resistance to all</b>, you can <b>move through creatures</b>, you <b>can’t cast leveled spells or make attacks</b>, and <b>enemies can’t make OAs</b> against you.',
+    '<b>Hemoplague (1/room).</b> <b>20-ft radius</b> point within 60 ft, Con save → target is <b>Plagued</b> until end of next turn (<b>+PB damage</b> from all sources), then it takes <b>6d6 necrotic</b> (success <b>3d6</b>). You <b>heal</b> for the total necrotic; excess healing becomes <b>Pact temp HP</b>.'
   ].join('<br><br>');
 
   function buildRollTemplate(title, rows) {
@@ -68,13 +68,13 @@
   }
 
   function buildSanguinePoolAction() {
-    return buildRollTemplate('Sanguine Pool (Reaction • 1/SR)', [
+    return buildRollTemplate('Sanguine Pool (Reaction • 1/room)', [
       { label: 'Effect', value: 'Until the start of your next turn you are blood mist: resistance to all damage; move through creatures; cannot cast leveled spells or make attacks; enemies cannot make OAs against you.' }
     ]);
   }
 
   function buildHemoplagueAction() {
-    return buildRollTemplate('Hemoplague (1/SR; 20-ft; 60 ft; Con save)', [
+    return buildRollTemplate('Hemoplague (1/room; 20-ft; 60 ft; Con save)', [
       { label: 'Plagued', value: 'Target is <b>Plagued</b> until end of its next turn (takes <b>+@{selected|hr_pb}</b> damage from all sources).' },
       { label: 'Then', value: 'Take [[ 6d6 ]] necrotic (success [[ 3d6 ]] necrotic).' },
       { label: 'Heal yourself', value: 'Equal to necrotic dealt; excess becomes Pact temp HP.' }
@@ -194,8 +194,8 @@
       abilities: [
         { name: 'Crimson Pact (Info)', action: buildCrimsonPactAction(), tokenAction: true },
         { name: 'Transfusion (Bonus)', action: buildTransfusionAction(), tokenAction: true },
-        { name: 'Sanguine Pool (Reaction • 1/SR)', action: buildSanguinePoolAction(), tokenAction: true },
-        { name: 'Hemoplague (1/SR)', action: buildHemoplagueAction(), tokenAction: true }
+        { name: 'Sanguine Pool (Reaction • 1/room)', action: buildSanguinePoolAction(), tokenAction: true },
+        { name: 'Hemoplague (1/room)', action: buildHemoplagueAction(), tokenAction: true }
       ],
       onInstall: onInstall
     });

--- a/src/modules/ancestorRegistry.js
+++ b/src/modules/ancestorRegistry.js
@@ -135,7 +135,7 @@ var AncestorRegistry = (function () {
         {
           id: 'azuren_shocking_orb',
           effectId: 'azuren_shocking_orb',
-          name: 'Shocking Orb (1/SR)',
+          name: 'Shocking Orb (1/room)',
           text_in_run:
             'Bonus Action; 90 ft. Make a ranged spell attack: on a hit, 3d8 lightning, and the target must make a Con save or be stunned until the end of its next turn.',
           hook: 'Summon'
@@ -223,7 +223,7 @@ var AncestorRegistry = (function () {
           id: 'vayla_twin_mantra',
           effectId: 'vayla_twin_mantra',
           name: 'Twin Mantra',
-          text_in_run: 'You can Mantra 2/Short Rest.',
+          text_in_run: 'You can Mantra 2/room.',
           hook: 'Balance'
         },
         {
@@ -255,7 +255,7 @@ var AncestorRegistry = (function () {
     references: 'Vladren Moroi.md',
     baseKit: {
       summary: 'Crimson Pact temp HP and necrotic siphons sustain the Blood Regent on the front line.',
-      html: '<div style="font-family:inherit;font-size:13px;line-height:1.25;"><h3 style="margin:0 0 6px 0;">Vladren Moroi — The Crimson Tide</h3><b>Crimson Pact.</b> Excess healing becomes <b>temp HP</b> (cap <b>5×PB + spell mod</b>). While you have Pact temp HP: <b>+1 AC</b>; your <b>necrotic ignores resistance</b> (treat immunity as resistance).<br><br><b>Transfusion (Bonus, 1/turn).</b> One creature within <b>60 ft</b> makes a <b>Con save</b>. Fail: <b>2d8 necrotic + PB</b> (success half). You <b>heal</b> for the damage dealt. If the target is <b>½ HP or less</b>, Transfusion deals <b>+1d8 necrotic</b>.<br><br><b>Sanguine Pool (Reaction, 1/SR).</b> When you take damage, become <b>blood mist</b> until the start of your next turn: <b>resistance to all</b>, you can <b>move through creatures</b>, you <b>can’t cast leveled spells or make attacks</b>, and <b>enemies can’t make OAs</b> against you.<br><br><b>Hemoplague (1/SR).</b> <b>20-ft radius</b> point within 60 ft, Con save → target is <b>Plagued</b> until end of next turn (<b>+PB damage</b> from all sources), then it takes <b>6d6 necrotic</b> (success <b>3d6</b>). You <b>heal</b> for the total necrotic; excess healing becomes <b>Pact temp HP</b>.</div>',
+      html: '<div style="font-family:inherit;font-size:13px;line-height:1.25;"><h3 style="margin:0 0 6px 0;">Vladren Moroi — The Crimson Tide</h3><b>Crimson Pact.</b> Excess healing becomes <b>temp HP</b> (cap <b>5×PB + spell mod</b>). While you have Pact temp HP: <b>+1 AC</b>; your <b>necrotic ignores resistance</b> (treat immunity as resistance).<br><br><b>Transfusion (Bonus, 1/turn).</b> One creature within <b>60 ft</b> makes a <b>Con save</b>. Fail: <b>2d8 necrotic + PB</b> (success half). You <b>heal</b> for the damage dealt. If the target is <b>½ HP or less</b>, Transfusion deals <b>+1d8 necrotic</b>.<br><br><b>Sanguine Pool (Reaction, 1/room).</b> When you take damage, become <b>blood mist</b> until the start of your next turn: <b>resistance to all</b>, you can <b>move through creatures</b>, you <b>can’t cast leveled spells or make attacks</b>, and <b>enemies can’t make OAs</b> against you.<br><br><b>Hemoplague (1/room).</b> <b>20-ft radius</b> point within 60 ft, Con save → target is <b>Plagued</b> until end of next turn (<b>+PB damage</b> from all sources), then it takes <b>6d6 necrotic</b> (success <b>3d6</b>). You <b>heal</b> for the total necrotic; excess healing becomes <b>Pact temp HP</b>.</div>',
       alwaysPreparedSpells: [],
       empowerments: []
     },
@@ -300,7 +300,7 @@ var AncestorRegistry = (function () {
         {
           id: 'vladren_crimson_apotheosis',
           effectId: 'vladren_crimson_apotheosis',
-          name: 'Crimson Apotheosis (1/SR)',
+          name: 'Crimson Apotheosis (1/room)',
           text_in_run:
             'For 2 rounds, your temp HP cap doubles, you have resistance to all damage, and Transfusion can be used twice each turn (still one Bonus Action each).',
           hook: 'Survival'
@@ -395,7 +395,7 @@ var AncestorRegistry = (function () {
         {
           id: 'lian_cataclysmic_shatter',
           effectId: 'lian_cataclysmic_shatter',
-          name: 'Cataclysmic Shatter (1/SR)',
+          name: 'Cataclysmic Shatter (1/room)',
           text_in_run:
             'This turn, Shatter is a Bonus Action and deals 3d8/stack + PB. Each time Shatter drops a creature this turn, all enemies within 10 ft of it gain 1 Veil.',
           hook: 'Burst'
@@ -474,7 +474,7 @@ var AncestorRegistry = (function () {
         {
           id: 'morvox_cataclysm',
           effectId: 'morvox_cataclysm',
-          name: 'Cataclysm (1/SR)',
+          name: 'Cataclysm (1/room)',
           text_in_run:
             'Primordial Burst becomes a Bonus Action and doesn’t consume Malice. Against targets at ½ HP or less, the save is made at disadvantage.',
           hook: 'Ultimate'
@@ -545,7 +545,7 @@ var AncestorRegistry = (function () {
         {
           id: 'seraphine_phoenix_bloom',
           effectId: 'seraphine_phoenix_bloom',
-          name: 'Phoenix Bloom (1/SR)',
+          name: 'Phoenix Bloom (1/room)',
           text_in_run:
             'Instantly Overheat and make two staff attacks. Then refund 25 Heat and move 10 ft without provoking.',
           hook: 'Revive'
@@ -553,7 +553,7 @@ var AncestorRegistry = (function () {
         {
           id: 'seraphine_phoenix_coronation',
           effectId: 'seraphine_phoenix_coronation',
-          name: 'Phoenix Coronation (1/SR)',
+          name: 'Phoenix Coronation (1/room)',
           text_in_run:
             'Empower a major burn: Fireball — after it resolves, the 20-ft radius edge becomes a Cinder Ring for 1 minute (ignited terrain; 1d6 fire on enter/start). Immolation — if the target dies while burning, the flames jump to a new creature within 15 ft (new save; remaining duration). This casting ignores fire resistance and treats immunity as resistance.',
           hook: 'Ultimate'

--- a/src/modules/effectRegistry.js
+++ b/src/modules/effectRegistry.js
@@ -224,8 +224,8 @@ var EffectRegistry = (function () {
         // Sanguine Pool gains +15 ft move on enter; recharges on 5–6 if THP >=10
         { type: 'attr', name: 'hr_pool_bonus_move_on_enter', op: 'set', value: 15 },
         { type: 'attr', name: 'hr_pool_recharge_5_6_if_thp10', op: 'set', value: 1 },
-        { type: 'ability', name: '[Vladren] Sanguine Pool (Reaction • 1/SR)', token: true,
-          action: '&{template:default} {{name=Sanguine Pool (Reaction • 1/SR)}} {{Effect=Until the start of your next turn you are blood mist: resistance to all damage; move through creatures; cannot cast leveled spells or make attacks; enemies cannot make OAs against you.}} {{On enter=When you enter the Pool, gain **+15 ft** movement.}} {{Recharge=At the start of your turn, recharge on a **5–6** while you have **≥10 temp HP**.}}' },
+        { type: 'ability', name: '[Vladren] Sanguine Pool (Reaction • 1/room)', token: true,
+          action: '&{template:default} {{name=Sanguine Pool (Reaction • 1/room)}} {{Effect=Until the start of your next turn you are blood mist: resistance to all damage; move through creatures; cannot cast leveled spells or make attacks; enemies cannot make OAs against you.}} {{On enter=When you enter the Pool, gain **+15 ft** movement.}} {{Recharge=At the start of your turn, recharge on a **5–6** while you have **≥10 temp HP**.}}' },
         { type: 'ability', name: '[Vladren] Sovereign Pool (Info)', token: false,
           action: '&{template:default} {{name=Sovereign Pool}} {{Move=When you enter, gain **+15 ft** movement}} {{Recharge=At start of your turn, **recharges on 5–6** while you have **≥10 temp HP**}}' },
         { type: 'note', text: 'Pool: +15 ft move on enter; recharge on 5–6 while you have ≥10 temp HP.' }
@@ -235,15 +235,15 @@ var EffectRegistry = (function () {
     'vladren_crimson_apotheosis': {
       id: 'vladren_crimson_apotheosis',
       name: 'Crimson Apotheosis',
-      source: 'Vladren Moroi (Signature, 1/SR)',
+      source: 'Vladren Moroi (Signature, 1/room)',
       patches: [
         // 2 rounds: temp HP cap doubles; resistance to all; Transfusion twice/turn
         { type: 'attr', name: 'hr_pact_cap_multiplier', op: 'set', value: 2 },
         { type: 'attr', name: 'hr_resistance_all_active', op: 'set', value: 1 },
         { type: 'attr', name: 'hr_transfusion_per_turn', op: 'set', value: 2 },
-        { type: 'ability', name: '[Vladren] Crimson Apotheosis (1/SR)', token: true,
-          action: '&{template:default} {{name=Crimson Apotheosis (1/SR)}} {{Duration=2 rounds}} {{Pact=Temp HP cap becomes [[ 2*(5*@{selected|hr_pb} + @{selected|hr_spellmod}) ]]}} {{Defense=**Resistance to all damage**}} {{Transfusion=Use **twice each turn** (still one Bonus Action each)}}' },
-        { type: 'note', text: 'Apotheosis (1/SR): 2 rounds. THP cap ×2; resistance to all; Transfusion ×2/turn.' }
+        { type: 'ability', name: '[Vladren] Crimson Apotheosis (1/room)', token: true,
+          action: '&{template:default} {{name=Crimson Apotheosis (1/room)}} {{Duration=2 rounds}} {{Pact=Temp HP cap becomes [[ 2*(5*@{selected|hr_pb} + @{selected|hr_spellmod}) ]]}} {{Defense=**Resistance to all damage**}} {{Transfusion=Use **twice each turn** (still one Bonus Action each)}}' },
+        { type: 'note', text: 'Apotheosis (1/room): 2 rounds. THP cap ×2; resistance to all; Transfusion ×2/turn.' }
       ]
     },
 
@@ -257,8 +257,8 @@ var EffectRegistry = (function () {
         { type: 'attr', name: 'hr_hemo_plague_bonus_damage', op: 'set', value: '2d6' },
         { type: 'attr', name: 'hr_necrotic_dc_bonus', op: 'set', value: 1 },
         { type: 'attr', name: 'hr_adv_vs_plagued', op: 'set', value: 1 },
-        { type: 'ability', name: '[Vladren] Hemoplague (1/SR)', token: true,
-          action: '&{template:default} {{name=Hemoplague (1/SR; 20-ft; 60 ft; Con save)}} {{Plagued=Target is <b>Plagued</b> until end of its next turn (takes <b>+@{selected|hr_pb}</b> damage from all sources) and is <b>vulnerable to necrotic</b> until the burst resolves.}} {{Burst=Then take [[ 6d6 + 2d6 ]] necrotic (success [[ 3d6 + 2d6 ]] necrotic).}} {{Dominance=While a creature is Plagued, you have advantage on attacks and +1 to spell save DC against it.}} {{Heal yourself=Equal to necrotic dealt; excess becomes Pact temp HP.}}' },
+        { type: 'ability', name: '[Vladren] Hemoplague (1/room)', token: true,
+          action: '&{template:default} {{name=Hemoplague (1/room; 20-ft; 60 ft; Con save)}} {{Plagued=Target is <b>Plagued</b> until end of its next turn (takes <b>+@{selected|hr_pb}</b> damage from all sources) and is <b>vulnerable to necrotic</b> until the burst resolves.}} {{Burst=Then take [[ 6d6 + 2d6 ]] necrotic (success [[ 3d6 + 2d6 ]] necrotic).}} {{Dominance=While a creature is Plagued, you have advantage on attacks and +1 to spell save DC against it.}} {{Heal yourself=Equal to necrotic dealt; excess becomes Pact temp HP.}}' },
         { type: 'ability', name: '[Vladren] Hemarch\u2019s Decree (Info)', token: true,
           action: '&{template:default} {{name=Hemarch’s Decree}} {{Hemoplague=Targets are **vulnerable to necrotic** until the burst}} {{Burst=Burst deals **+2d6 necrotic**}} {{Targeting=You have **advantage** on attacks and **+1** to spell save DC vs **Plagued** creatures}}' },
         { type: 'note', text: 'Hemoplague: necrotic vuln; burst +2d6 necrotic; +1 DC & advantage vs Plagued.' }


### PR DESCRIPTION
## Summary
- update ancestor registry entries to label limited-use abilities as 1/room instead of 1/SR
- sync Vladren kit macros and effect patches to the per-room cadence
- clarify the `!resetvladren` command description to reference per-room charge resets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5faacdd80832e91819090f85522c3