### PR TITLE
feat: add guardian's band relic

### DIFF
--- a/src/data/relics.js
+++ b/src/data/relics.js
@@ -175,6 +175,16 @@ var RelicData = (function () {
       "tags": ["Defense", "Survival", "Cleanse"]
     },
     {
+      "id": "relic_guardians_band_C",
+      "name": "Guardian's Band",
+      "rarity": "Common",
+      "category": "Defense",
+      "price": 30,
+      "text_in_run": "Gain a +1 bonus to AC.",
+      "uses": { "cadence": "per_room", "value": 0 },
+      "tags": ["Defense", "Armor", "Passive"]
+    },
+    {
       "id": "relic_counterglyph_C",
       "name": "Counterglyph",
       "rarity": "Common",


### PR DESCRIPTION
## Summary
- add the Guardian's Band relic to the defense catalog to provide a passive +1 AC bonus for testing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e601db1830832eab0089ce0c4d6d28