### PR TITLE
feat: install Vladren always prepared spells

### DIFF
--- a/src/modules/ancestorKits.vladren.js
+++ b/src/modules/ancestorKits.vladren.js
@@ -173,6 +173,20 @@
 
     upsertAttr('hr_pb', pbValue);
     upsertAttr('hr_spellmod', spellModValue);
+
+    // Install Vladren's Always Prepared spell list and token actions when available.
+    if (typeof SpellbookHelper !== 'undefined') {
+      SpellbookHelper.installAlwaysPrepared(charId, [
+        { name: 'False Life', level: 1, school: 'Necromancy', range: 'Self', components: 'V,S,M', duration: '1 hour', effect: 'Gain temp HP as per spell.' },
+        { name: 'Ray of Sickness', level: 1, school: 'Necromancy', range: '60 ft', components: 'V,S', duration: 'Instant', hit: 'Ranged spell attack; poison on failed Con save.' },
+        { name: 'Ray of Enfeeblement', level: 2, school: 'Necromancy', range: '60 ft', components: 'V,S', duration: '1 minute (Concentration)', effect: 'Target deals half damage with Str attacks (save ends).' },
+        { name: 'Mirror Image', level: 2, school: 'Illusion', range: 'Self', components: 'V,S', duration: '1 minute', effect: 'Creates illusory duplicates (no concentration).' },
+        { name: 'Vampiric Touch', level: 3, school: 'Necromancy', range: 'Self', components: 'V,S', duration: '1 minute (Concentration)', hit: 'Melee spell attack; necrotic; heal half the damage dealt each hit.' },
+        { name: 'Blight', level: 4, school: 'Necromancy', range: '30 ft', components: 'V,S', duration: 'Instant', effect: '8d8 necrotic; plant creatures have disadvantage and take max dmg.' },
+        { name: 'Enervation', level: 5, school: 'Necromancy', range: '60 ft', components: 'V,S', duration: '1 minute (Concentration)', effect: 'Ray drains 4d8 necrotic; repeat 4d8 each turn while maintained.' },
+        { name: 'Negative Energy Flood', level: 5, school: 'Necromancy', range: '60 ft', components: 'V,M', duration: 'Instant', effect: '5d12 necrotic; humanoid killed may rise as zombie under your control.' }
+      ]);
+    }
   }
 
   var _registered = false;

--- a/src/modules/spellbookHelper.js
+++ b/src/modules/spellbookHelper.js
@@ -1,0 +1,152 @@
+// ------------------------------------------------------------
+// Spellbook Helper
+// ------------------------------------------------------------
+// What this does (in simple terms):
+//   • Adds "Always Prepared" spells to a bound character when an Ancestor is chosen.
+//   • Creates token-action macros for those spells (reliable casting buttons).
+//   • If the sheet looks like D&D5e by Roll20, it tries to also create/update
+//     the underlying repeating spell entries (nice-to-have).
+//   • Exposes patch helpers so boons can modify a specific spell later.
+// ------------------------------------------------------------
+
+var SpellbookHelper = (function () {
+  'use strict';
+
+  // --- Utilities ---
+  function getChar(charId)             { return getObj('character', charId); }
+  function getAttrObj(charId, name)    { return findObjs({ _type:'attribute', _characterid: charId, name: name })[0] || null; }
+  function setAttr(charId, name, val)  {
+    var a = getAttrObj(charId, name);
+    if (!a) a = createObj('attribute', { _characterid: charId, name: name, current: val });
+    else a.set('current', val);
+    return a;
+  }
+  function newRowId() {
+    // Roll20 UPPERCASE A–Z, 0–9 random id works fine for repeating rows
+    var s='ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', r='';
+    for (var i=0;i<19;i++){ r+=s[Math.floor(Math.random()*s.length)]; }
+    return r;
+  }
+  function upsertAbility(charId, name, action, token) {
+    var a = findObjs({ _type:'ability', _characterid: charId, name: name })[0];
+    if (!a) a = createObj('ability', { _characterid: charId, name: name, action: action, istokenaction: !!token });
+    else a.set({ action: action, istokenaction: !!token });
+    return a;
+  }
+  function hasOGL5eSignals(charId) {
+    // lightweight sniff: OGL/5e by Roll20 tends to have these attrs around
+    return !!(getAttrObj(charId, 'level') || getAttrObj(charId, 'class') || getAttrObj(charId, 'spellcasting_ability'));
+  }
+
+  // --- Build a safe cast macro (works regardless of sheet) ---
+  function buildCastCard(spell) {
+    var rows = [];
+    if (spell.school) rows.push('{{School=' + spell.school + '}}');
+    if (spell.level !== undefined) rows.push('{{Level=' + (spell.level===0 ? 'Cantrip' : spell.level) + '}}');
+    if (spell.range) rows.push('{{Range=' + spell.range + '}}');
+    if (spell.components) rows.push('{{Components=' + spell.components + '}}');
+    if (spell.duration) rows.push('{{Duration=' + spell.duration + '}}');
+    if (spell.hit) rows.push('{{On Hit=' + spell.hit + '}}');
+    if (spell.save) rows.push('{{Save=' + spell.save + '}}');
+    if (spell.effect) rows.push('{{Effect=' + spell.effect + '}}');
+    if (spell.notes) rows.push('{{Notes=' + spell.notes + '}}');
+
+    return '&{template:default} {{name=' + spell.name + '}} ' + rows.join(' ');
+  }
+
+  // --- Try to install as a repeating spell on OGL/5e (best-effort) ---
+  function tryInstallOnOGL5e(charId, spell) {
+    try {
+      if (!hasOGL5eSignals(charId)) return false;
+
+      var lvl    = spell.level || 0;
+      var secKey = (lvl === 0) ? 'repeating_spell-cantrip' : ('repeating_spell' + lvl);
+      var row    = newRowId();
+      var base   = secKey + '_' + row + '_';
+
+      // Minimum viable fields for the sheet to render it
+      setAttr(charId, base + 'spellname', spell.name);
+      setAttr(charId, base + 'spelllevel', lvl);
+      setAttr(charId, base + 'spellschool', spell.school || '');
+      setAttr(charId, base + 'spellrange', spell.range || '');
+      setAttr(charId, base + 'spellduration', spell.duration || '');
+      setAttr(charId, base + 'spellcomponents', spell.components || '');
+      setAttr(charId, base + 'spellattack', spell.attack || '');
+      setAttr(charId, base + 'spelldamage', spell.damage || spell.hit || '');
+      setAttr(charId, base + 'spelldamage2', spell.damage2 || '');
+      setAttr(charId, base + 'spelldamagetype', spell.dmgtype || '');
+      setAttr(charId, base + 'spellritual', '0');
+
+      // Prepared + always prepared
+      setAttr(charId, base + 'spellprepared', 'on');
+      setAttr(charId, base + 'spellalwaysprepared', 'on');
+
+      // Description (sheet uses this for the card)
+      setAttr(charId, base + 'spelldescription', (spell.effect || spell.notes || ''));
+
+      // We store a back-link so we can find it later by spell name
+      // (helps us patch it when a boon modifies it)
+      var tagName = 'hr_apspell_' + spell.name.toLowerCase().replace(/[^a-z0-9]+/g,'_');
+      setAttr(charId, tagName, base); // base prefix lets us update the row fields later
+
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // --- Public: install a list of Always Prepared spells ---
+  // spells: [{ name, level, school, range, components, duration, hit/save/effect/notes... }]
+  function installAlwaysPrepared(charId, spells) {
+    if (!charId || !spells || !spells.length) return;
+    for (var i=0;i<spells.length;i++){
+      var s = spells[i];
+
+      // 1) Always create a token-action cast macro so it Just Works™
+      upsertAbility(charId, '[AP] ' + s.name, buildCastCard(s), true);
+
+      // 2) Best-effort: add to OGL5e repeating spell list as prepared
+      tryInstallOnOGL5e(charId, s);
+    }
+  }
+
+  // --- Public: apply a modifier to a specific AP spell (by name) ---
+  // modify: { fields: {spelldamage: '2d8+PB', spelldescription: '...' }, macroNotes: 'adds +PB temp HP' }
+  function patchAPSpell(charId, spellName, modify) {
+    if (!charId || !spellName || !modify) return false;
+    var tagName = 'hr_apspell_' + spellName.toLowerCase().replace(/[^a-z0-9]+/g,'_');
+    var base = getAttrObj(charId, tagName);
+    var patched = false;
+
+    // Try patching sheet first if we have a base prefix
+    if (base) {
+      var prefix = base.get('current') || '';
+      if (prefix) {
+        var fields = modify.fields || {};
+        for (var k in fields) {
+          if (fields.hasOwnProperty(k)) {
+            setAttr(charId, prefix + k, fields[k]);
+            patched = true;
+          }
+        }
+      }
+    }
+
+    // Always update the token-action macro, so the casting button reflects changes
+    var a = findObjs({ _type:'ability', _characterid: charId, name: '[AP] ' + spellName })[0];
+    if (a) {
+      var note = modify.macroNotes ? (' {{Boon=' + modify.macroNotes + '}}') : '';
+      var current = a.get('action') || '';
+      // naive approach: append a Boon line (idempotent-ish in testing contexts)
+      a.set('action', current + note);
+      patched = true;
+    }
+
+    return patched;
+  }
+
+  return {
+    installAlwaysPrepared: installAlwaysPrepared,
+    patchAPSpell: patchAPSpell
+  };
+})();


### PR DESCRIPTION
## Summary
- add a SpellbookHelper module to manage always prepared spells and token actions
- hook Vladren's onInstall to grant his always prepared spell list when bound

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e608a4605c832eabbb35b2e39e805e